### PR TITLE
Integrate run tree (`KGenRunInfo`) with Artus/KappaAnalysis

### DIFF
--- a/KappaAnalysis/data/example/hlt_info.json
+++ b/KappaAnalysis/data/example/hlt_info.json
@@ -15,6 +15,7 @@
 	],
 	"InputIsData": "false",
 	"LumiMetadata": "lumiInfo",
+	"RunMetadata": "runInfo",
 	"OutputPath": "output.root",
 	"Pipelines": {
 		"hlt_info": {

--- a/KappaAnalysis/interface/KappaEvent.h
+++ b/KappaAnalysis/interface/KappaEvent.h
@@ -90,6 +90,7 @@ public:
 	KGenEventInfo* m_genEventInfo = nullptr;
 	KLumiInfo* m_lumiInfo = nullptr;
 	KGenLumiInfo* m_genLumiInfo = nullptr;
+	KGenRunInfo* m_genRunInfo = nullptr;
 	KFilterMetadata* m_filterMetadata = nullptr;
 	KFilterSummary* m_filterSummary = nullptr;
 	KJetMetadata* m_jetMetadata = nullptr;

--- a/KappaAnalysis/interface/KappaEventProvider.h
+++ b/KappaAnalysis/interface/KappaEventProvider.h
@@ -128,7 +128,7 @@ public:
 				this->m_event.m_eventInfo = this->m_event.m_genEventInfo;
 			}
 		}
-		
+
 		if (! settings.GetLumiMetadata().empty())
 		{
 			if(settings.GetInputIsData())
@@ -139,6 +139,14 @@ public:
 			{
 				this->m_event.m_genLumiInfo = this->template SecureFileInterfaceGetMeta<KGenLumiInfo>(settings.GetLumiMetadata());
 				this->m_event.m_lumiInfo = this->m_event.m_genLumiInfo;
+			}
+		}
+
+		if (! settings.GetRunMetadata().empty())
+		{
+			if (!settings.GetInputIsData())
+			{
+				this->m_event.m_genRunInfo = this->template SecureFileInterfaceGetMeta<KGenRunInfo>(settings.GetRunMetadata());
 			}
 		}
 		if (! settings.GetFilterMetadata().empty())

--- a/KappaAnalysis/interface/KappaSettings.h
+++ b/KappaAnalysis/interface/KappaSettings.h
@@ -92,6 +92,9 @@ public:
 	/// name of lumiMetaData in kappa tuple
 	IMPL_SETTING_DEFAULT(std::string, LumiMetadata, "");
 
+	/// name of runMetaData in kappa tuple
+	IMPL_SETTING_DEFAULT(std::string, RunMetadata, "");
+
 	/// name of filterMetaData in kappa tuple
 	IMPL_SETTING_DEFAULT(std::string, FilterMetadata, "");
 

--- a/KappaAnalysisExample/data/KappaExampleWithCustomProcessors.json
+++ b/KappaAnalysisExample/data/KappaExampleWithCustomProcessors.json
@@ -7,6 +7,7 @@
 	"comment1" : "Read in event/lumi metadata and the muon collection",
 	"EventMetadata" : "eventInfo",
 	"LumiMetadata" : "lumiInfo",
+	"RunMetadata" : "runInfo",
 	"Muons" : "muons",
 	
 	"OutputPath" : "output.root",

--- a/KappaAnalysisExample/data/SimpleKappaExample.json
+++ b/KappaAnalysisExample/data/SimpleKappaExample.json
@@ -7,6 +7,7 @@
 	"comment1" : "Read in event/lumi metadata and the muon collection",
 	"EventMetadata" : "eventInfo",
 	"LumiMetadata" : "lumiInfo",
+	"RunMetadata" : "runInfo",
 	"Muons" : "muons",
 	
 	"OutputPath" : "output.root",


### PR DESCRIPTION
On the current `master` branch,  `KappaEvent` has a member `m_genLumiInfo` of type `KGenLumiInfo` (see [KappaEvent.h](https://github.com/KIT-CMS/Artus/blob/master/KappaAnalysis/interface/KappaEvent.h#L92)), but no member `m_genRunInfo` of type `KGenRunInfo`.

On the other hand, the `master` branch in Kappa has already merged changes which change the content of
`KGenLumiInfo` (see [KInfo.h](https://github.com/KIT-CMS/Kappa/blob/cbd18523f5783a81b6b0acc17f746bd35a3da3ae/DataFormats/interface/KInfo.h#L44-L58))

So now, with the current `master` branches of Kappa and Artus, neither of these work:
```
event.m_genRunInfo->xSectionExt   // event has no member 'm_genRunInfo'
event.m_genLumiInfo->xSectionExt  // KGenLumiInfo has no member 'xSectionExt'
```

I think we need to synchronize the `master` branches across all repositories, so that they all compile.

This PR adds `KGenLumiInfo* m_genRunInfo` to the `KappaEvent` in an attempt to fix that.

I already updated the KappaTools `master` branch with a temporary workaround for this issue. This involved committing some changes from KappaTools `getByToken` to KappaTools `master`, since the old `master` led to compilation errors. The issue would be solved by completely merging the `getByToken` branch there (see [this PR](https://github.com/KIT-CMS/KappaTools/pull/1)).

Could someone review and possibly merge these changes?
