### PR TITLE
Remove dependency on `VertexRefit/TauRefit` package.

### DIFF
--- a/KappaAnalysis/interface/KappaEvent.h
+++ b/KappaAnalysis/interface/KappaEvent.h
@@ -67,10 +67,6 @@ public:
 	/// pointer to primary vertex summary
 	KVertexSummary* m_vertexSummary = nullptr;
 
-	/// pointer to the refitted vertices collection
-	KRefitVertices* m_refitVertices = nullptr;
-	KRefitVertices* m_refitBSVertices = nullptr;
-
 	/// pointer to track summary
 	KTrackSummary* m_trackSummary = nullptr;
 

--- a/KappaAnalysis/interface/KappaEventProvider.h
+++ b/KappaAnalysis/interface/KappaEventProvider.h
@@ -100,10 +100,6 @@ public:
 			this->m_event.m_beamSpot = this->template SecureFileInterfaceGet<KBeamSpot>(settings.GetBeamSpot());
 		if (! settings.GetVertexSummary().empty())
 			this->m_event.m_vertexSummary = this->template SecureFileInterfaceGet<KVertexSummary>(settings.GetVertexSummary());
-		if (! settings.GetRefitVertices().empty())
-			this->m_event.m_refitVertices = this->template SecureFileInterfaceGet<KRefitVertices>(settings.GetRefitVertices());
-		if (! settings.GetRefitBSVertices().empty())
-			this->m_event.m_refitBSVertices = this->template SecureFileInterfaceGet<KRefitVertices>(settings.GetRefitBSVertices());
 
 		// Track summary
 		if (! settings.GetTrackSummary().empty())

--- a/KappaAnalysis/interface/KappaSettings.h
+++ b/KappaAnalysis/interface/KappaSettings.h
@@ -67,10 +67,6 @@ public:
 	/// name of vertexSummary collection in kappa tuple
 	IMPL_SETTING_DEFAULT(std::string, VertexSummary, "");
 
-	/// name of refit vertices collection in kappa tuple
-	IMPL_SETTING_DEFAULT(std::string, RefitVertices, "");
-	IMPL_SETTING_DEFAULT(std::string, RefitBSVertices, "");
-
 	/// name of track summary collection in kappa tuple
 	IMPL_SETTING_DEFAULT(std::string, TrackSummary, "");
 


### PR DESCRIPTION
This PR removes the relevant `KappaEvent` members after the removal of the `TauRefit`-dependency from Kappa.

For more info, see [this PR in Kappa](https://github.com/KIT-CMS/Kappa/pull/4).