### PR TITLE
WIP Reduced trigger objects memleak

### DIFF
--- a/Consumer/interface/DrawHist1dConsumer.h
+++ b/Consumer/interface/DrawHist1dConsumer.h
@@ -4,8 +4,7 @@
 #include "DrawConsumerBase.h"
 #include "Hist1D.h"
 /*
- typedef std::function<
- std::vector<float>(MassRecoEvent const&, MassRecoProduct const&)> ValueExtractLambda;
+ typedef std::function<std::vector<float>(MassRecoEvent const&, MassRecoProduct const&)> ValueExtractLambda;
  typedef std::pair<ValueExtractLambda, ValueModifiers> ValueDesc;
  */
 template<class TTypes>
@@ -16,9 +15,7 @@ public:
 	typedef typename TTypes::product_type product_type;
 	typedef typename TTypes::setting_type setting_type;
 
-	typedef std::function<
-			std::vector<float>(event_type const&, product_type const&
-                                )> ValueExtractLambda;
+	typedef std::function<std::vector<float>(event_type const&, product_type const&, setting_type const&)> ValueExtractLambda;
 	typedef std::pair<ValueExtractLambda, ValueModifiers> ValueDesc;
 
 	DrawHist1dConsumerBase(std::string const& histName, ValueDesc desc) :
@@ -57,7 +54,7 @@ public:
 
 		DrawConsumerBase<TTypes>::ProcessFilteredEvent(event, product, setting );
 
-		auto res = m_desc.first(event, product);
+		auto res = m_desc.first(event, product, setting);
 
 		for (auto const& v : res) {
 			getHist()->Fill(v, 1.0f);

--- a/Consumer/interface/LambdaNtupleConsumer.h
+++ b/Consumer/interface/LambdaNtupleConsumer.h
@@ -32,19 +32,19 @@
 class LambdaNtupleQuantities {
 
 public:
-	static std::map<std::string, std::function<bool(EventBase const&, ProductBase const& ) >> CommonBoolQuantities;
-	static std::map<std::string, std::function<int(EventBase const&, ProductBase const& ) >> CommonIntQuantities;
-	static std::map<std::string, std::function<uint64_t(EventBase const&, ProductBase const& ) >> CommonUInt64Quantities;
-	static std::map<std::string, std::function<float(EventBase const&, ProductBase const& ) >> CommonFloatQuantities;
-	static std::map<std::string, std::function<double(EventBase const&, ProductBase const& ) >> CommonDoubleQuantities;
-	static std::map<std::string, std::function<ROOT::Math::PtEtaPhiMVector(EventBase const&, ProductBase const& ) >> CommonPtEtaPhiMVectorQuantities;
-	static std::map<std::string, std::function<RMFLV(EventBase const&, ProductBase const& ) >> CommonRMFLVQuantities;
-	static std::map<std::string, std::function<std::string(EventBase const&, ProductBase const& ) >> CommonStringQuantities;
-	static std::map<std::string, std::function<std::vector<double>(EventBase const&, ProductBase const& ) >> CommonVDoubleQuantities;
-	static std::map<std::string, std::function<std::vector<float>(EventBase const&, ProductBase const& ) >> CommonVFloatQuantities;
-	static std::map<std::string, std::function<std::vector<RMFLV>(EventBase const&, ProductBase const& ) >> CommonVRMFLVQuantities;
-	static std::map<std::string, std::function<std::vector<std::string>(EventBase const&, ProductBase const& ) >> CommonVStringQuantities;
-	static std::map<std::string, std::function<std::vector<int>(EventBase const&, ProductBase const& ) >> CommonVIntQuantities;
+	static std::map<std::string, std::function<bool(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonBoolQuantities;
+	static std::map<std::string, std::function<int(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonIntQuantities;
+	static std::map<std::string, std::function<uint64_t(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonUInt64Quantities;
+	static std::map<std::string, std::function<float(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonFloatQuantities;
+	static std::map<std::string, std::function<double(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonDoubleQuantities;
+	static std::map<std::string, std::function<ROOT::Math::PtEtaPhiMVector(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonPtEtaPhiMVectorQuantities;
+	static std::map<std::string, std::function<RMFLV(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonRMFLVQuantities;
+	static std::map<std::string, std::function<std::string(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonStringQuantities;
+	static std::map<std::string, std::function<std::vector<double>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonVDoubleQuantities;
+	static std::map<std::string, std::function<std::vector<float>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonVFloatQuantities;
+	static std::map<std::string, std::function<std::vector<RMFLV>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonVRMFLVQuantities;
+	static std::map<std::string, std::function<std::vector<std::string>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonVStringQuantities;
+	static std::map<std::string, std::function<std::vector<int>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> CommonVIntQuantities;
 };
 
 template<class TTypes>
@@ -57,190 +57,203 @@ public:
 	typedef typename TTypes::product_type product_type;
 	typedef typename TTypes::setting_type setting_type;
 
-	typedef std::function<bool(EventBase const&, ProductBase const&)> bool_extractor_lambda_base;
-	typedef std::function<int(EventBase const&, ProductBase const&)> int_extractor_lambda_base;
-	typedef std::function<uint64_t(EventBase const&, ProductBase const&)> uint64_extractor_lambda_base;
-	typedef std::function<float(EventBase const&, ProductBase const&)> float_extractor_lambda_base;
-	typedef std::function<double(EventBase const&, ProductBase const&)> double_extractor_lambda_base;
-	typedef std::function<ROOT::Math::PtEtaPhiMVector(EventBase const&, ProductBase const&)> ptEtaPhiMVector_extractor_lambda_base;
-	typedef std::function<RMFLV(EventBase const&, ProductBase const&)> rmflv_extractor_lambda_base;
-	typedef std::function<std::string(EventBase const&, ProductBase const&)> string_extractor_lambda_base;
-	typedef std::function<std::vector<double>(EventBase const&, ProductBase const&)> vDouble_extractor_lambda_base;
-	typedef std::function<std::vector<float>(EventBase const&, ProductBase const&)> vFloat_extractor_lambda_base;
-	typedef std::function<std::vector<RMFLV>(EventBase const&, ProductBase const&)> vRMFLV_extractor_lambda_base;
-	typedef std::function<std::vector<std::string>(EventBase const&, ProductBase const&)> vString_extractor_lambda_base;
-	typedef std::function<std::vector<int>(EventBase const&, ProductBase const&)> vInt_extractor_lambda_base;
+	typedef std::function<bool(EventBase const&, ProductBase const&, SettingsBase const&)> bool_extractor_lambda_base;
+	typedef std::function<int(EventBase const&, ProductBase const&, SettingsBase const&)> int_extractor_lambda_base;
+	typedef std::function<uint64_t(EventBase const&, ProductBase const&, SettingsBase const&)> uint64_extractor_lambda_base;
+	typedef std::function<float(EventBase const&, ProductBase const&, SettingsBase const&)> float_extractor_lambda_base;
+	typedef std::function<double(EventBase const&, ProductBase const&, SettingsBase const&)> double_extractor_lambda_base;
+	typedef std::function<ROOT::Math::PtEtaPhiMVector(EventBase const&, ProductBase const&, SettingsBase const&)> ptEtaPhiMVector_extractor_lambda_base;
+	typedef std::function<RMFLV(EventBase const&, ProductBase const&, SettingsBase const&)> rmflv_extractor_lambda_base;
+	typedef std::function<std::string(EventBase const&, ProductBase const&, SettingsBase const&)> string_extractor_lambda_base;
+	typedef std::function<std::vector<double>(EventBase const&, ProductBase const&, SettingsBase const&)> vDouble_extractor_lambda_base;
+	typedef std::function<std::vector<float>(EventBase const&, ProductBase const&, SettingsBase const&)> vFloat_extractor_lambda_base;
+	typedef std::function<std::vector<RMFLV>(EventBase const&, ProductBase const&, SettingsBase const&)> vRMFLV_extractor_lambda_base;
+	typedef std::function<std::vector<std::string>(EventBase const&, ProductBase const&, SettingsBase const&)> vString_extractor_lambda_base;
+	typedef std::function<std::vector<int>(EventBase const&, ProductBase const&, SettingsBase const&)> vInt_extractor_lambda_base;
 
 
 	static void AddBoolQuantity(std::string const& name,
-	                            std::function<bool(event_type const&, product_type const&)> valueExtractor)
+	                            std::function<bool(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonBoolQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> bool
+		LambdaNtupleQuantities::CommonBoolQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> bool
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
 	static void AddIntQuantity(std::string const& name,
-	                           std::function<int(event_type const&, product_type const&)> valueExtractor)
+	                           std::function<int(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonIntQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> int
+		LambdaNtupleQuantities::CommonIntQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> int
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
 	static void AddUInt64Quantity(std::string const& name,
-	                              std::function<uint64_t(event_type const&, product_type const&)> valueExtractor)
+	                              std::function<uint64_t(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonUInt64Quantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> uint64_t
+		LambdaNtupleQuantities::CommonUInt64Quantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> uint64_t
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
 	static void AddFloatQuantity(std::string const& name,
-	                             std::function<float(event_type const&, product_type const&)> valueExtractor)
+	                             std::function<float(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonFloatQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> float
+		LambdaNtupleQuantities::CommonFloatQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> float
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
 	static void AddDoubleQuantity(std::string const& name,
-	                              std::function<double(event_type const&, product_type const&)> valueExtractor)
+	                              std::function<double(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonDoubleQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> double
+		LambdaNtupleQuantities::CommonDoubleQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> double
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
 	static void AddPtEtaPhiMVectorQuantity(std::string const& name,
-	                              std::function<ROOT::Math::PtEtaPhiMVector(event_type const&, product_type const&)> valueExtractor)
+	                              std::function<ROOT::Math::PtEtaPhiMVector(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonPtEtaPhiMVectorQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> ROOT::Math::PtEtaPhiMVector
+		LambdaNtupleQuantities::CommonPtEtaPhiMVectorQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> ROOT::Math::PtEtaPhiMVector
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
 	static void AddRMFLVQuantity(std::string const& name,
-	                              std::function<RMFLV(event_type const&, product_type const&)> valueExtractor)
+	                              std::function<RMFLV(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonRMFLVQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> RMFLV
+		LambdaNtupleQuantities::CommonRMFLVQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> RMFLV
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
 	static void AddStringQuantity(std::string const& name,
-	                              std::function<std::string(event_type const&, product_type const&)> valueExtractor)
+	                              std::function<std::string(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonStringQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> std::string
+		LambdaNtupleQuantities::CommonStringQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> std::string
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
 	static void AddVDoubleQuantity(std::string const& name,
-	                              std::function<std::vector<double>(event_type const&, product_type const&)> valueExtractor)
+	                              std::function<std::vector<double>(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonVDoubleQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> std::vector<double>
+		LambdaNtupleQuantities::CommonVDoubleQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> std::vector<double>
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
 	static void AddVFloatQuantity(std::string const& name,
-	                              std::function<std::vector<float>(event_type const&, product_type const&)> valueExtractor)
+	                              std::function<std::vector<float>(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonVFloatQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> std::vector<float>
+		LambdaNtupleQuantities::CommonVFloatQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> std::vector<float>
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
 	static void AddVRMFLVQuantity(std::string const& name,
-	                              std::function<std::vector<RMFLV>(event_type const&, product_type const&)> valueExtractor)
+	                              std::function<std::vector<RMFLV>(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonVRMFLVQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> std::vector<RMFLV>
+		LambdaNtupleQuantities::CommonVRMFLVQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> std::vector<RMFLV>
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
 	static void AddVStringQuantity(std::string const& name,
-	                              std::function<std::vector<std::string>(event_type const&, product_type const&)> valueExtractor)
+	                              std::function<std::vector<std::string>(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonVStringQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> std::vector<std::string>
+		LambdaNtupleQuantities::CommonVStringQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> std::vector<std::string>
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
 	static void AddVIntQuantity(std::string const& name,
-	                              std::function<std::vector<int>(event_type const&, product_type const&)> valueExtractor)
+	                              std::function<std::vector<int>(event_type const&, product_type const&, setting_type const&)> valueExtractor)
 	{
-		LambdaNtupleQuantities::CommonVIntQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd) -> std::vector<int>
+		LambdaNtupleQuantities::CommonVIntQuantities[name] = [valueExtractor](EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) -> std::vector<int>
 		{
-			auto const& specEv = static_cast<event_type const&>(ev);
-			auto const& specPd = static_cast<product_type const&>(pd);
-			return valueExtractor(specEv, specPd);
+			auto const& specEvent = static_cast<event_type const&>(ev);
+			auto const& specProduct = static_cast<product_type const&>(pd);
+			setting_type const& specSettings = static_cast<setting_type const&>(settings);
+            return valueExtractor(specEvent, specProduct, specSettings);
 		};
 	}
-	
 
-	static std::map<std::string, std::function<bool(EventBase const&, ProductBase const& ) >> & GetBoolQuantities () {
+
+	static std::map<std::string, std::function<bool(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetBoolQuantities () {
 		return LambdaNtupleQuantities::CommonBoolQuantities;
 	}
-	static std::map<std::string, std::function<int(EventBase const&, ProductBase const& ) >> & GetIntQuantities () {
+	static std::map<std::string, std::function<int(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetIntQuantities () {
 		return LambdaNtupleQuantities::CommonIntQuantities;
 	}
-	static std::map<std::string, std::function<uint64_t(EventBase const&, ProductBase const& ) >> & GetUInt64Quantities () {
+	static std::map<std::string, std::function<uint64_t(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetUInt64Quantities () {
 		return LambdaNtupleQuantities::CommonUInt64Quantities;
 	}
-	static std::map<std::string, std::function<float(EventBase const&, ProductBase const& ) >> & GetFloatQuantities () {
+	static std::map<std::string, std::function<float(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetFloatQuantities () {
 		return LambdaNtupleQuantities::CommonFloatQuantities;
 	}
-	static std::map<std::string, std::function<double(EventBase const&, ProductBase const& ) >> & GetDoubleQuantities () {
+	static std::map<std::string, std::function<double(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetDoubleQuantities () {
 		return LambdaNtupleQuantities::CommonDoubleQuantities;
 	}
-	static std::map<std::string, std::function<std::string(EventBase const&, ProductBase const& ) >> & GetStringQuantities () {
+	static std::map<std::string, std::function<std::string(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetStringQuantities () {
 		return LambdaNtupleQuantities::CommonStringQuantities;
 	}
-	static std::map<std::string, std::function<ROOT::Math::PtEtaPhiMVector(EventBase const&, ProductBase const& ) >> & GetPtEtaPhiMVectorQuantities () {
+	static std::map<std::string, std::function<ROOT::Math::PtEtaPhiMVector(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetPtEtaPhiMVectorQuantities () {
 		return LambdaNtupleQuantities::CommonPtEtaPhiMVectorQuantities;
 	}
-	static std::map<std::string, std::function<RMFLV(EventBase const&, ProductBase const& ) >> & GetRMFLVQuantities () {
+	static std::map<std::string, std::function<RMFLV(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetRMFLVQuantities () {
 		return LambdaNtupleQuantities::CommonRMFLVQuantities;
 	}
-	static std::map<std::string, std::function<std::vector<double>(EventBase const&, ProductBase const& ) >> & GetVDoubleQuantities () {
+	static std::map<std::string, std::function<std::vector<double>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetVDoubleQuantities () {
 		return LambdaNtupleQuantities::CommonVDoubleQuantities;
 	}
-	static std::map<std::string, std::function<std::vector<float>(EventBase const&, ProductBase const& ) >> & GetVFloatQuantities () {
+	static std::map<std::string, std::function<std::vector<float>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetVFloatQuantities () {
 		return LambdaNtupleQuantities::CommonVFloatQuantities;
 	}
-	static std::map<std::string, std::function<std::vector<RMFLV>(EventBase const&, ProductBase const& ) >> & GetVRMFLVQuantities () {
+	static std::map<std::string, std::function<std::vector<RMFLV>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetVRMFLVQuantities () {
 		return LambdaNtupleQuantities::CommonVRMFLVQuantities;
 	}
-	static std::map<std::string, std::function<std::vector<std::string>(EventBase const&, ProductBase const& ) >> & GetVStringQuantities () {
+	static std::map<std::string, std::function<std::vector<std::string>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetVStringQuantities () {
 		return LambdaNtupleQuantities::CommonVStringQuantities;
 	}
-	static std::map<std::string, std::function<std::vector<int>(EventBase const&, ProductBase const& ) >> & GetVIntQuantities () {
+	static std::map<std::string, std::function<std::vector<int>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> & GetVIntQuantities () {
 		return LambdaNtupleQuantities::CommonVIntQuantities;
 	}
 
@@ -261,7 +274,7 @@ public:
 		m_vRMFLVValueExtractors.clear();
 		m_vStringValueExtractors.clear();
 		m_vIntValueExtractors.clear();
-		
+
 		m_boolQuantities.clear();
 		m_intQuantities.clear();
 		m_uint64Quantities.clear();
@@ -275,7 +288,7 @@ public:
 		m_vRMFLVQuantities.clear();
 		m_vStringQuantities.clear();
 		m_vIntQuantities.clear();
-		
+
 		size_t quantityIndex = 0;
 		for (std::vector<std::string>::iterator quantity = settings.GetQuantities().begin();
 		     quantity != settings.GetQuantities().end(); ++quantity)
@@ -482,7 +495,7 @@ public:
 		{
 			try
 			{
-				m_boolValues[boolValueIndex] = (*valueExtractor)(event, product);
+				m_boolValues[boolValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{
@@ -497,7 +510,7 @@ public:
 		{
 			try
 			{
-				m_intValues[intValueIndex] = (*valueExtractor)(event, product);
+				m_intValues[intValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{
@@ -512,7 +525,7 @@ public:
 		{
 			try
 			{
-				m_uint64Values[uint64ValueIndex] = (*valueExtractor)(event, product);
+				m_uint64Values[uint64ValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{
@@ -527,7 +540,7 @@ public:
 		{
 			try
 			{
-				m_floatValues[floatValueIndex] = (*valueExtractor)(event, product);
+				m_floatValues[floatValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{
@@ -542,7 +555,7 @@ public:
 		{
 			try
 			{
-				m_doubleValues[doubleValueIndex] = (*valueExtractor)(event, product);
+				m_doubleValues[doubleValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{
@@ -550,14 +563,14 @@ public:
 			}
 			++doubleValueIndex;
 		}
-		
+
 		size_t ptEtaPhiMVectorValueIndex = 0;
 		for(typename std::vector<ptEtaPhiMVector_extractor_lambda_base>::iterator valueExtractor = m_ptEtaPhiMVectorValueExtractors.begin();
 		    valueExtractor != m_ptEtaPhiMVectorValueExtractors.end(); ++valueExtractor)
 		{
 			try
 			{
-				m_ptEtaPhiMVectorValues[ptEtaPhiMVectorValueIndex] = (*valueExtractor)(event, product);
+				m_ptEtaPhiMVectorValues[ptEtaPhiMVectorValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{
@@ -565,14 +578,14 @@ public:
 			}
 			++ptEtaPhiMVectorValueIndex;
 		}
-		
+
 		size_t rmflvValueIndex = 0;
 		for(typename std::vector<rmflv_extractor_lambda_base>::iterator valueExtractor = m_rmflvValueExtractors.begin();
 		    valueExtractor != m_rmflvValueExtractors.end(); ++valueExtractor)
 		{
 			try
 			{
-				m_rmflvValues[rmflvValueIndex] = (*valueExtractor)(event, product);
+				m_rmflvValues[rmflvValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{
@@ -580,14 +593,14 @@ public:
 			}
 			++rmflvValueIndex;
 		}
-		
+
 		size_t stringValueIndex = 0;
 		for(typename std::vector<string_extractor_lambda_base>::iterator valueExtractor = m_stringValueExtractors.begin();
 		    valueExtractor != m_stringValueExtractors.end(); ++valueExtractor)
 		{
 			try
 			{
-				m_stringValues[stringValueIndex] = (*valueExtractor)(event, product);
+				m_stringValues[stringValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{
@@ -595,14 +608,14 @@ public:
 			}
 			++stringValueIndex;
 		}
-		
+
 		size_t vDoubleValueIndex = 0;
 		for(typename std::vector<vDouble_extractor_lambda_base>::iterator valueExtractor = m_vDoubleValueExtractors.begin();
 		    valueExtractor != m_vDoubleValueExtractors.end(); ++valueExtractor)
 		{
 			try
 			{
-				m_vDoubleValues[vDoubleValueIndex] = (*valueExtractor)(event, product);
+				m_vDoubleValues[vDoubleValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{
@@ -610,14 +623,14 @@ public:
 			}
 			++vDoubleValueIndex;
 		}
-		
+
 		size_t vFloatValueIndex = 0;
 		for(typename std::vector<vFloat_extractor_lambda_base>::iterator valueExtractor = m_vFloatValueExtractors.begin();
 		    valueExtractor != m_vFloatValueExtractors.end(); ++valueExtractor)
 		{
 			try
 			{
-				m_vFloatValues[vFloatValueIndex] = (*valueExtractor)(event, product);
+				m_vFloatValues[vFloatValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{
@@ -625,14 +638,14 @@ public:
 			}
 			++vFloatValueIndex;
 		}
-		
+
 		size_t vRMFLVValueIndex = 0;
 		for(typename std::vector<vRMFLV_extractor_lambda_base>::iterator valueExtractor = m_vRMFLVValueExtractors.begin();
 		    valueExtractor != m_vRMFLVValueExtractors.end(); ++valueExtractor)
 		{
 			try
 			{
-				m_vRMFLVValues[vRMFLVValueIndex] = (*valueExtractor)(event, product);
+				m_vRMFLVValues[vRMFLVValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{
@@ -640,14 +653,14 @@ public:
 			}
 			++vRMFLVValueIndex;
 		}
-		
+
 		size_t vStringValueIndex = 0;
 		for(typename std::vector<vString_extractor_lambda_base>::iterator valueExtractor = m_vStringValueExtractors.begin();
 		    valueExtractor != m_vStringValueExtractors.end(); ++valueExtractor)
 		{
 			try
 			{
-				m_vStringValues[vStringValueIndex] = (*valueExtractor)(event, product);
+				m_vStringValues[vStringValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{
@@ -662,7 +675,7 @@ public:
 		{
 			try
 			{
-				m_vIntValues[vIntValueIndex] = (*valueExtractor)(event, product);
+				m_vIntValues[vIntValueIndex] = (*valueExtractor)(event, product, settings);
 			}
 			catch (...)
 			{

--- a/Consumer/interface/ProfileConsumerBase.h
+++ b/Consumer/interface/ProfileConsumerBase.h
@@ -14,9 +14,7 @@ public:
 	typedef typename TTypes::product_type product_type;
 	typedef typename TTypes::setting_type setting_type;
 
-	typedef std::function<
-			std::vector<float>(event_type const&, product_type const& )>
-					            ValueExtractLambda;
+	typedef std::function<std::vector<float>(event_type const&, product_type const&, setting_type const&)> ValueExtractLambda;
 	typedef std::pair<ValueExtractLambda, ValueModifiers> ValueDesc;
 
 	typedef Pipeline<TTypes> PipelineTypeForThis;
@@ -64,8 +62,8 @@ public:
 	{
 		ConsumerBase<TTypes>::ProcessFilteredEvent(event, product, setting);
 
-		auto resX = m_xsource.first(event, product);
-		auto resY = m_ysource.first(event, product);
+		auto resX = m_xsource.first(event, product, setting);
+		auto resY = m_ysource.first(event, product, setting);
 
 		if ((resX.size() == 0) || (resY.size() == 0))
 			return;

--- a/Consumer/src/LambdaNtupleConsumer.cc
+++ b/Consumer/src/LambdaNtupleConsumer.cc
@@ -1,44 +1,44 @@
 #include "Artus/Consumer/interface/LambdaNtupleConsumer.h"
 
 
-std::map<std::string, std::function<bool(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonBoolQuantities
-	= std::map<std::string, std::function<bool(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<bool(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonBoolQuantities
+	= std::map<std::string, std::function<bool(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
-std::map<std::string, std::function<int(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonIntQuantities
-	= std::map<std::string, std::function<int(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<int(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonIntQuantities
+	= std::map<std::string, std::function<int(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
-std::map<std::string, std::function<uint64_t(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonUInt64Quantities
-	= std::map<std::string, std::function<uint64_t(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<uint64_t(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonUInt64Quantities
+	= std::map<std::string, std::function<uint64_t(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
-std::map<std::string, std::function<float(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonFloatQuantities
-	= std::map<std::string, std::function<float(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<float(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonFloatQuantities
+	= std::map<std::string, std::function<float(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
-std::map<std::string, std::function<double(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonDoubleQuantities
-	= std::map<std::string, std::function<double(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<double(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonDoubleQuantities
+	= std::map<std::string, std::function<double(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
-std::map<std::string, std::function<ROOT::Math::PtEtaPhiMVector(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonPtEtaPhiMVectorQuantities
-	= std::map<std::string, std::function<ROOT::Math::PtEtaPhiMVector(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<ROOT::Math::PtEtaPhiMVector(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonPtEtaPhiMVectorQuantities
+	= std::map<std::string, std::function<ROOT::Math::PtEtaPhiMVector(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
-std::map<std::string, std::function<RMFLV(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonRMFLVQuantities
-	= std::map<std::string, std::function<RMFLV(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<RMFLV(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonRMFLVQuantities
+	= std::map<std::string, std::function<RMFLV(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
-std::map<std::string, std::function<std::string(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonStringQuantities
-	= std::map<std::string, std::function<std::string(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<std::string(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonStringQuantities
+	= std::map<std::string, std::function<std::string(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
-std::map<std::string, std::function<std::vector<double>(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonVDoubleQuantities
-	= std::map<std::string, std::function<std::vector<double>(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<std::vector<double>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonVDoubleQuantities
+	= std::map<std::string, std::function<std::vector<double>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
-std::map<std::string, std::function<std::vector<float>(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonVFloatQuantities
-	= std::map<std::string, std::function<std::vector<float>(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<std::vector<float>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonVFloatQuantities
+	= std::map<std::string, std::function<std::vector<float>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
-std::map<std::string, std::function<std::vector<RMFLV>(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonVRMFLVQuantities
-	= std::map<std::string, std::function<std::vector<RMFLV>(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<std::vector<RMFLV>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonVRMFLVQuantities
+	= std::map<std::string, std::function<std::vector<RMFLV>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
-std::map<std::string, std::function<std::vector<std::string>(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonVStringQuantities
-	= std::map<std::string, std::function<std::vector<std::string>(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<std::vector<std::string>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonVStringQuantities
+	= std::map<std::string, std::function<std::vector<std::string>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
-std::map<std::string, std::function<std::vector<int>(EventBase const&, ProductBase const& ) >> LambdaNtupleQuantities::CommonVIntQuantities
-	= std::map<std::string, std::function<std::vector<int>(EventBase const&, ProductBase const& ) >>();
+std::map<std::string, std::function<std::vector<int>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >> LambdaNtupleQuantities::CommonVIntQuantities
+	= std::map<std::string, std::function<std::vector<int>(EventBase const& ev, ProductBase const& pd, SettingsBase const& settings) >>();
 
 
 

--- a/Core/interface/EventProviderBase.h
+++ b/Core/interface/EventProviderBase.h
@@ -14,7 +14,7 @@ public:
 	// returns false for non-existing entries, e.g. when lEventNumber >= GetEntries()
 	// this is important as termination condition of the event loop in the PipelineRunner
 	virtual bool GetEntry(long long lEventNumber) = 0;
-
+    virtual ~EventProviderBase() {}
 	virtual long long GetEntries() const = 0;
 	virtual bool NewLumisection() const { return false; }
 	virtual bool NewRun() const { return false; }

--- a/Core/interface/Pipeline.h
+++ b/Core/interface/Pipeline.h
@@ -17,7 +17,7 @@ template<class TTypes>
 class Pipeline;
 
 /**
-   \brief Base class for your custom PipelineInitializer. 
+   \brief Base class for your custom PipelineInitializer.
 
    Your custom code can add Filters and Consumers to newly created pipelines.
  */
@@ -33,41 +33,41 @@ public:
 	typedef Pipeline<TTypes> pipeline_type;
 
 	virtual void InitPipeline(pipeline_type * pLine, setting_type const& pset) const {};
-
+	virtual ~PipelineInitilizerBase() {};
 };
 
 /**
    \brief Base implementation of the Pipeline paradigm.
 
-   The Pipline contains settings, producer, filter and consumer which, when combined, produce the 
-   desired output of a pipeline as soon as Events are send to the pipeline. An incoming event must 
-   not be changed by the pipeline but the pipeline can create additional data for an event using 
-   Producers. Most of the time, the Pipeline will not be used stand-alone but by an PipelineRunner 
-   class. 
+   The Pipline contains settings, producer, filter and consumer which, when combined, produce the
+   desired output of a pipeline as soon as Events are send to the pipeline. An incoming event must
+   not be changed by the pipeline but the pipeline can create additional data for an event using
+   Producers. Most of the time, the Pipeline will not be used stand-alone but by an PipelineRunner
+   class.
 
    The intention of the different components is outlined in the following:
-   
-   
+
+
    - Settings
-   Contain all specifics for the behaviour of this pipeline. The Settings object of type TSettings 
+   Contain all specifics for the behaviour of this pipeline. The Settings object of type TSettings
    must be used to steer the behaviour of the Producers, Filters and Consumers.
-   
+
    - Producers
-   Create additional, pipeline-specific, data for an event and stores this information in a TProduct 
+   Create additional, pipeline-specific, data for an event and stores this information in a TProduct
    object.
-   
+
    - Filters
-   Decide whether an input event is suitable to be processed by this pipeline. An event might not be 
-   in the desired PtRange and is therefore not useful for this pipeline. The FilterResult is stored 
+   Decide whether an input event is suitable to be processed by this pipeline. An event might not be
+   in the desired PtRange and is therefore not useful for this pipeline. The FilterResult is stored
    and Consumers can access the outcome of the Filter process.
-   
+
    - Consumers
-   Can access the input event, the created products, the settings and the filter result and produce 
+   Can access the input event, the created products, the settings and the filter result and produce
    the output they desire, like Histograms -> PLOTS PLOTS PLOTS
-   
-   Execution order is: Producers -> Filters -> Consumers. Each pipeline can have several Producers, 
+
+   Execution order is: Producers -> Filters -> Consumers. Each pipeline can have several Producers,
    Filters or Consumers.
-   
+
 */
 
 template<class TTypes>
@@ -92,7 +92,7 @@ public:
 	virtual ~Pipeline() {
 	}
 
-	/// Initialize the pipeline using a custom PipelineInitilizer. This PipelineInitilizerBase 
+	/// Initialize the pipeline using a custom PipelineInitilizer. This PipelineInitilizerBase
 	/// can create specific Filters and Consumers
 	virtual void InitPipeline(setting_type pset,
 			PipelineInitilizerBase<TTypes> const& initializer) {
@@ -150,7 +150,7 @@ public:
 		}
 	}
 
-	/// Run the pipeline without specific event input. This is most useful for Pipelines which 
+	/// Run the pipeline without specific event input. This is most useful for Pipelines which
 	/// process output from Pipelines already run.
 	virtual void Run() {
 		for (auto & it : m_consumer) {
@@ -158,7 +158,7 @@ public:
 		}
 	}
 
-	/// Run the pipeline with one specific event as input. GlobalProduct are products which are 
+	/// Run the pipeline with one specific event as input. GlobalProduct are products which are
 	/// common for all pipelines and have therefore been created only once.
 	virtual bool RunEvent(event_type const& evt,
 			product_type const& globalProduct,

--- a/Example/src/TraxPipelineInitializer.cc
+++ b/Example/src/TraxPipelineInitializer.cc
@@ -11,21 +11,21 @@ void TraxPipelineInitializer::InitPipeline(TraxPipeline * pLine, TraxSettings co
 
 	// define how to extract Pt and the range
 	auto extractPtSim =
-			[]( TraxEvent const& ev, TraxProduct const & prod )
+			[]( TraxEvent const& ev, TraxProduct const & prod, TraxSettings const& pset )
 			-> std::vector<float> {return {ev.m_floatPtSim};};
 	auto PtSimValue = std::make_pair(extractPtSim,
 			DefaultModifiers::getPtModifier(0.7, 1.3f));
 
 	// extracts the value which has been corrected by a globalProducer
 	auto extractPtSimCorrected =
-			[]( TraxEvent const& ev, TraxProduct const & prod )
+			[]( TraxEvent const& ev, TraxProduct const & prod, TraxSettings const& pset )
 			-> std::vector<float> {return {prod.m_floatPtSim_corrected};};
 	auto PtSimCorrectedValue = std::make_pair(extractPtSimCorrected,
 			DefaultModifiers::getPtModifier(0.7, 1.3f));
 
 	// define how to extract Theta and the range
 	auto extractThetaSim =
-			[]( TraxEvent const& ev, TraxProduct const & prod )
+			[]( TraxEvent const& ev, TraxProduct const & prod, TraxSettings const& pset )
 			-> std::vector<float> {return {ev.m_floatTheSim};};
 
 	auto ThetaSimValue = std::make_pair(extractThetaSim,

--- a/Filter/interface/CutFilterBase.h
+++ b/Filter/interface/CutFilterBase.h
@@ -16,39 +16,32 @@ public:
 	typedef typename TTypes::event_type event_type;
 	typedef typename TTypes::product_type product_type;
 	typedef typename TTypes::setting_type setting_type;
-	
-	typedef typename std::function<double(event_type const&, product_type const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(event_type const&, product_type const&, setting_type const&)> double_extractor_lambda;
+
 	void Init(setting_type const& settings)  override
 	{
 		FilterBase<TTypes>::Init(settings);
 	}
 
-	bool DoesEventPass(event_type const& event,
-			product_type const& product, setting_type const& settings) const override
+	virtual bool DoesEventPass(event_type const& event, product_type const& product, setting_type const& settings) const
 	{
-		return DoesEventPass(event, product);
+		bool passAllCuts = true;
+
+		for (auto cut : m_cuts)
+		{
+			passAllCuts = passAllCuts && cut.second.IsInRange(cut.first(event, product, settings));
+			if (! passAllCuts) {
+				break;
+			}
+		}
+
+		return passAllCuts;
 	}
 
 protected:
 	std::vector<std::pair<double_extractor_lambda, CutRange> > m_cuts;
 
 
-private:
-
-	virtual bool DoesEventPass(event_type const& event, product_type const& product) const
-	{
-		bool passAllCuts = true;
-		
-		for (auto cut : m_cuts)
-		{
-			passAllCuts = passAllCuts && cut.second.IsInRange(cut.first(event, product));
-			if (! passAllCuts) {
-				break;
-			}
-		}
-		
-		return passAllCuts;
-	}
 };
 

--- a/KappaAnalysis/interface/Consumers/KappaLambdaNtupleConsumer.h
+++ b/KappaAnalysis/interface/Consumers/KappaLambdaNtupleConsumer.h
@@ -26,118 +26,118 @@ public:
 	void Init(setting_type const& settings) override
 	{
 		// add possible quantities for the lambda ntuples consumers
-		LambdaNtupleConsumer<TTypes>::AddIntQuantity("input", [](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<TTypes>::AddIntQuantity("input", [](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return static_cast<int>(event.m_input);
 		});
-		LambdaNtupleConsumer<TTypes>::AddUInt64Quantity("run", [](event_type const& event, product_type const& product) -> uint64_t
+		LambdaNtupleConsumer<TTypes>::AddUInt64Quantity("run", [](event_type const& event, product_type const& product, setting_type const& settings) -> uint64_t
 		{
 			return event.m_eventInfo->nRun;
 		});
-		LambdaNtupleConsumer<TTypes>::AddUInt64Quantity("lumi", [](event_type const& event, product_type const& product) -> uint64_t
+		LambdaNtupleConsumer<TTypes>::AddUInt64Quantity("lumi", [](event_type const& event, product_type const& product, setting_type const& settings) -> uint64_t
 		{
 			return event.m_eventInfo->nLumi;
 		});
-		LambdaNtupleConsumer<TTypes>::AddUInt64Quantity("event", [](event_type const& event, product_type const& product) -> uint64_t
+		LambdaNtupleConsumer<TTypes>::AddUInt64Quantity("event", [](event_type const& event, product_type const& product, setting_type const& settings) -> uint64_t
 		{
 			return event.m_eventInfo->nEvent;
-		});		
-		LambdaNtupleConsumer<TTypes>::AddUInt64Quantity("nbx", [](event_type const& event, product_type const& product) -> uint64_t
+		});
+		LambdaNtupleConsumer<TTypes>::AddUInt64Quantity("nbx", [](event_type const& event, product_type const& product, setting_type const& settings) -> uint64_t
 		{
 			return event.m_eventInfo->nBX;
 		});
-		LambdaNtupleConsumer<TTypes>::AddIntQuantity("npv", [](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<TTypes>::AddIntQuantity("npv", [](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return event.m_vertexSummary->nVertices;
 		});
 
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("firstPV_X", [](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("firstPV_X", [](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return event.m_vertexSummary->pv.position.X();
 		});
 
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("firstPV_Y", [](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("firstPV_Y", [](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return event.m_vertexSummary->pv.position.Y();
 		});
 
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("firstPV_Z", [](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("firstPV_Z", [](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return event.m_vertexSummary->pv.position.Z();
 		});
 
 		bool bInpData = settings.GetInputIsData();
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("npuMean", [bInpData](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("npuMean", [bInpData](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			if (bInpData)
 				return DefaultValues::UndefinedFloat;
 			return static_cast<KGenEventInfo*>(event.m_eventInfo)->nPUMean;
 		});
 
-		LambdaNtupleConsumer<TTypes>::AddIntQuantity("npu", [bInpData](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<TTypes>::AddIntQuantity("npu", [bInpData](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			if (bInpData)
 				return DefaultValues::UndefinedInt;
 			return static_cast<int>(static_cast<KGenEventInfo*>(event.m_eventInfo)->nPU);
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("x1", [bInpData](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("x1", [bInpData](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (bInpData) ? DefaultValues::UndefinedFloat : float(static_cast<KGenEventInfo*>(event.m_eventInfo)->x1);
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("x2", [bInpData](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("x2", [bInpData](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (bInpData) ? DefaultValues::UndefinedFloat : float(static_cast<KGenEventInfo*>(event.m_eventInfo)->x2);
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("qScale", [bInpData](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("qScale", [bInpData](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (bInpData) ? DefaultValues::UndefinedFloat : float(static_cast<KGenEventInfo*>(event.m_eventInfo)->qScale);
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("rho", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("rho", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_pileupDensity->rho;
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("PFMet", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("PFMet", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_met->p4.Pt();
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("trackmet", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("trackmet", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_trackMet->p4.Pt();
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("trackmetphi", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("trackmetphi", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_trackMet->p4.Phi();
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("trackmetsumet", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("trackmetsumet", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_trackMet->sumEt;
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("pumet", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("pumet", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_puMet->p4.Pt();
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("pumetphi", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("pumetphi", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_puMet->p4.Phi();
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("pumetsumet", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("pumetsumet", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_puMet->sumEt;
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("nopumet", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("nopumet", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_noPuMet->p4.Pt();
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("nopumetphi", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("nopumetphi", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_noPuMet->p4.Phi();
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("nopumetsumet", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("nopumetsumet", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_noPuMet->sumEt;
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("pucormet", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("pucormet", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_puCorMet->p4.Pt();
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("pucormetphi", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("pucormetphi", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_puCorMet->p4.Phi();
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("pucormetsumet", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("pucormetsumet", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return event.m_puCorMet->sumEt;
 		});
-		LambdaNtupleConsumer<TTypes>::AddIntQuantity("genNPartons", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddIntQuantity("genNPartons", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return product.m_genNPartons;
 		});
-		LambdaNtupleConsumer<TTypes>::AddIntQuantity("NPFCandidates", [](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<TTypes>::AddIntQuantity("NPFCandidates", [](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return event.m_packedPFCandidates->size();
 		});
@@ -151,7 +151,7 @@ public:
 			    (LambdaNtupleConsumer<TTypes>::GetDoubleQuantities().count(quantity) == 0))
 			{
 				LOG(DEBUG) << "\tQuantity \"" << quantity << "\" is tried to be taken from product.m_weights or product.m_optionalWeights.";
-				LambdaNtupleConsumer<TTypes>::AddFloatQuantity( quantity, [quantity](event_type const & event, product_type const & product)
+				LambdaNtupleConsumer<TTypes>::AddFloatQuantity( quantity, [quantity](event_type const& event, product_type const& product, setting_type const& settings)
 				{
 					return SafeMap::GetWithDefault(product.m_weights, quantity, SafeMap::GetWithDefault(product.m_optionalWeights, quantity, 1.0));
 				} );
@@ -160,7 +160,7 @@ public:
 			   (LambdaNtupleConsumer<TTypes>::GetFloatQuantities().count(quantity) == 0))
 			{
 				LOG(DEBUG) << "\tQuantity \"" << quantity << "\" is tried to be taken from product.fres (FilterResult).";
-				LambdaNtupleConsumer<TTypes>::AddIntQuantity( quantity, [quantity](event_type const & event, product_type const & product)
+				LambdaNtupleConsumer<TTypes>::AddIntQuantity( quantity, [quantity](event_type const& event, product_type const& product, setting_type const& settings)
 				{
 					if (product.fres.GetDecisionEntry(quantity) != nullptr)
 					{
@@ -170,7 +170,7 @@ public:
 				} );
 			}
 		}
-		
+
 		// need to be called at last
 		LambdaNtupleConsumer<TTypes>::Init(settings);
 	}

--- a/KappaAnalysis/interface/Filters/MaxObjectsCountFilters.h
+++ b/KappaAnalysis/interface/Filters/MaxObjectsCountFilters.h
@@ -10,9 +10,9 @@
  */
 class MaxElectronsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -23,9 +23,9 @@ public:
  */
 class MaxMuonsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -36,9 +36,9 @@ public:
  */
 class MaxTausCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -49,9 +49,9 @@ public:
  */
 class MaxJetsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -62,9 +62,9 @@ public:
  */
 class MaxBTaggedJetsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -75,9 +75,9 @@ public:
  */
 class MaxNonBTaggedJetsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };

--- a/KappaAnalysis/interface/Filters/MinObjectsCountFilters.h
+++ b/KappaAnalysis/interface/Filters/MinObjectsCountFilters.h
@@ -10,9 +10,9 @@
  */
 class MinElectronsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -23,9 +23,9 @@ public:
  */
 class MinMuonsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -36,9 +36,9 @@ public:
  */
 class MinTausCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -49,9 +49,9 @@ public:
  */
 class MinJetsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -62,9 +62,9 @@ public:
  */
 class MinBTaggedJetsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -75,9 +75,9 @@ public:
  */
 class MinNonBTaggedJetsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };

--- a/KappaAnalysis/interface/Filters/ObjectsCountFilters.h
+++ b/KappaAnalysis/interface/Filters/ObjectsCountFilters.h
@@ -10,9 +10,9 @@
  */
 class ElectronsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -23,9 +23,9 @@ public:
  */
 class MuonsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -36,9 +36,9 @@ public:
  */
 class TausCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -50,7 +50,7 @@ public:
 class JetsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
 
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
 
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
@@ -63,7 +63,7 @@ public:
 class BTaggedJetsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
 
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
 
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
@@ -76,7 +76,7 @@ public:
 class NonBTaggedJetsCountFilter: public CutRangeFilterBase<KappaTypes> {
 public:
 
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
 
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;

--- a/KappaAnalysis/interface/Filters/ObjectsLowerPtCutFilters.h
+++ b/KappaAnalysis/interface/Filters/ObjectsLowerPtCutFilters.h
@@ -15,9 +15,9 @@
 template<class TLepton>
 class LeptonLowerPtCutsFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	explicit LeptonLowerPtCutsFilter(std::vector<TLepton*> KappaProduct::*validLeptons) :
 		CutRangeFilterBase<KappaTypes>(),
 		m_validLeptonsMember(validLeptons)
@@ -29,7 +29,7 @@ protected:
 
 	void Initialise(std::vector<std::string> const& leptonLowerPtCutsVector) {
 		std::map<std::string, std::vector<std::string> > leptonLowerPtCuts = Utility::ParseVectorToMap(leptonLowerPtCutsVector);
-	
+
 		std::vector<int> defaultIndices = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
 		for (std::map<std::string, std::vector<std::string> >::const_iterator leptonLowerPtCut = leptonLowerPtCuts.begin();
 		     leptonLowerPtCut != leptonLowerPtCuts.end(); ++leptonLowerPtCut)
@@ -48,17 +48,17 @@ protected:
 					hltNames.push_back(leptonLowerPtCut->first);
 				}
 			}
-			
+
 			for (std::vector<std::string>::const_iterator ptCut = leptonLowerPtCut->second.begin();
 			     ptCut != leptonLowerPtCut->second.end(); ++ptCut)
 			{
 				double ptCutValue = std::stod(*ptCut);
-				
+
 				for (std::vector<int>::iterator index = indices.begin(); index != indices.end(); ++index)
 				{
 					size_t tmpIndex(*index); // TODO
 					this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-							[this, tmpIndex](KappaEvent const& event, KappaProduct const& product) -> double {
+							[this, tmpIndex](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) -> double {
 								return (((product.*m_validLeptonsMember).size() > tmpIndex) ?
 								        (product.*m_validLeptonsMember).at(tmpIndex)->p4.Pt() :
 								        0.99*std::numeric_limits<double>::max());
@@ -66,7 +66,7 @@ protected:
 							CutRange::LowerThresholdCut(ptCutValue)
 					));
 				}
-				
+
 				for (std::vector<std::string>::iterator hltName = hltNames.begin(); hltName != hltNames.end(); ++hltName)
 				{
 					std::string tmpHltName(*hltName); // TODO
@@ -75,7 +75,7 @@ protected:
 					{
 						size_t tmpIndex(*index);
 						this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-								[this, tmpHltName, pattern, tmpIndex](KappaEvent const& event, KappaProduct const& product) -> double {
+								[this, tmpHltName, pattern, tmpIndex](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) -> double {
 									bool hasMatch = false;
 									for (unsigned int iHlt = 0; iHlt < product.m_selectedHltNames.size(); ++iHlt)
 										hasMatch = hasMatch || boost::regex_search(product.m_selectedHltNames.at(iHlt), pattern);
@@ -89,7 +89,7 @@ protected:
 					}
 				}
 			}
-		}	
+		}
 	}
 
 
@@ -102,11 +102,11 @@ private:
  */
 class ElectronLowerPtCutsFilter: public LeptonLowerPtCutsFilter<KElectron> {
 public:
-	
+
 	std::string GetFilterId() const override;
-	
+
 	ElectronLowerPtCutsFilter();
-	
+
 	void Init(KappaSettings const& settings) override;
 };
 
@@ -115,11 +115,11 @@ public:
  */
 class MuonLowerPtCutsFilter: public LeptonLowerPtCutsFilter<KMuon> {
 public:
-	
+
 	std::string GetFilterId() const override;
-	
+
 	MuonLowerPtCutsFilter();
-	
+
 	void Init(KappaSettings const& settings) override;
 };
 
@@ -128,11 +128,11 @@ public:
  */
 class TauLowerPtCutsFilter: public LeptonLowerPtCutsFilter<KTau> {
 public:
-	
+
 	std::string GetFilterId() const override;
-	
+
 	TauLowerPtCutsFilter();
-	
+
 	void Init(KappaSettings const& settings) override;
 };
 
@@ -141,11 +141,11 @@ public:
  */
 class JetLowerPtCutsFilter: public LeptonLowerPtCutsFilter<KBasicJet> {
 public:
-	
+
 	std::string GetFilterId() const override;
-	
+
 	JetLowerPtCutsFilter();
-	
+
 	void Init(KappaSettings const& settings) override;
 };
 
@@ -154,10 +154,10 @@ public:
  */
 class NonBTaggedJetLowerPtCutsFilter: public LeptonLowerPtCutsFilter<KJet> {
 public:
-	
+
 	std::string GetFilterId() const override;
-	
+
 	NonBTaggedJetLowerPtCutsFilter();
-	
+
 	void Init(KappaSettings const& settings) override;
 };

--- a/KappaAnalysis/interface/Filters/ObjectsUpperAbsEtaCutFilters.h
+++ b/KappaAnalysis/interface/Filters/ObjectsUpperAbsEtaCutFilters.h
@@ -16,9 +16,9 @@
 template<class TLepton>
 class LeptonUpperAbsEtaCutsFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	explicit LeptonUpperAbsEtaCutsFilter(std::vector<TLepton*> KappaProduct::*validLeptons) :
 		CutRangeFilterBase<KappaTypes>(),
 		m_validLeptonsMember(validLeptons)
@@ -30,7 +30,7 @@ protected:
 
 	void Initialise(std::vector<std::string> const& leptonUpperAbsEtaCutsVector) {
 		std::map<std::string, std::vector<std::string> > leptonUpperAbsEtaCuts = Utility::ParseVectorToMap(leptonUpperAbsEtaCutsVector);
-	
+
 		std::vector<int> defaultIndices = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
 		for (std::map<std::string, std::vector<std::string> >::const_iterator leptonUpperAbsEtaCut = leptonUpperAbsEtaCuts.begin();
 		     leptonUpperAbsEtaCut != leptonUpperAbsEtaCuts.end(); ++leptonUpperAbsEtaCut)
@@ -49,17 +49,17 @@ protected:
 					hltNames.push_back(leptonUpperAbsEtaCut->first);
 				}
 			}
-			
+
 			for (std::vector<std::string>::const_iterator absEtaCut = leptonUpperAbsEtaCut->second.begin();
 			     absEtaCut != leptonUpperAbsEtaCut->second.end(); ++absEtaCut)
 			{
 				double absEtaCutValue = std::stod(*absEtaCut);
-				
+
 				for (std::vector<int>::iterator index = indices.begin(); index != indices.end(); ++index)
 				{
 					size_t tmpIndex(*index); // TODO
 					this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-							[this, tmpIndex](KappaEvent const& event, KappaProduct const& product) -> double {
+							[this, tmpIndex](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) -> double {
 								return (((product.*m_validLeptonsMember).size() > tmpIndex) ?
 								        std::abs((product.*m_validLeptonsMember).at(tmpIndex)->p4.Eta()) :
 								        -1.0);
@@ -67,7 +67,7 @@ protected:
 							CutRange::UpperThresholdCut(absEtaCutValue)
 					));
 				}
-				
+
 				for (std::vector<std::string>::iterator hltName = hltNames.begin(); hltName != hltNames.end(); ++hltName)
 				{
 					std::string tmpHltName(*hltName); // TODO
@@ -76,7 +76,7 @@ protected:
 					{
 						size_t tmpIndex(*index);
 						this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-								[this, tmpHltName, pattern, tmpIndex](KappaEvent const& event, KappaProduct const& product) -> double {
+								[this, tmpHltName, pattern, tmpIndex](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) -> double {
 									bool hasMatch = false;
 									for (unsigned int iHlt = 0; iHlt < product.m_selectedHltNames.size(); ++iHlt)
 										hasMatch = hasMatch || boost::regex_search(product.m_selectedHltNames.at(iHlt), pattern);
@@ -90,7 +90,7 @@ protected:
 					}
 				}
 			}
-		}	
+		}
 	}
 
 
@@ -103,11 +103,11 @@ private:
  */
 class ElectronUpperAbsEtaCutsFilter: public LeptonUpperAbsEtaCutsFilter<KElectron> {
 public:
-	
+
 	std::string GetFilterId() const override;
-	
+
 	ElectronUpperAbsEtaCutsFilter();
-	
+
 	void Init(KappaSettings const& settings) override;
 };
 
@@ -116,11 +116,11 @@ public:
  */
 class MuonUpperAbsEtaCutsFilter: public LeptonUpperAbsEtaCutsFilter<KMuon> {
 public:
-	
+
 	std::string GetFilterId() const override;
-	
+
 	MuonUpperAbsEtaCutsFilter();
-	
+
 	void Init(KappaSettings const& settings) override;
 };
 
@@ -129,11 +129,11 @@ public:
  */
 class TauUpperAbsEtaCutsFilter: public LeptonUpperAbsEtaCutsFilter<KTau> {
 public:
-	
+
 	std::string GetFilterId() const override;
-	
+
 	TauUpperAbsEtaCutsFilter();
-	
+
 	void Init(KappaSettings const& settings) override;
 };
 
@@ -142,11 +142,11 @@ public:
  */
 class JetUpperAbsEtaCutsFilter: public LeptonUpperAbsEtaCutsFilter<KBasicJet> {
 public:
-	
+
 	std::string GetFilterId() const override;
-	
+
 	JetUpperAbsEtaCutsFilter();
-	
+
 	void Init(KappaSettings const& settings) override;
 };
 

--- a/KappaAnalysis/interface/Filters/ValidObjectsFilters.h
+++ b/KappaAnalysis/interface/Filters/ValidObjectsFilters.h
@@ -10,9 +10,9 @@
  */
 class ValidElectronsFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -22,9 +22,9 @@ public:
  */
 class ValidMuonsFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -34,9 +34,9 @@ public:
  */
 class ValidTausFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -46,9 +46,9 @@ public:
  */
 class ValidJetsFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -58,9 +58,9 @@ public:
  */
 class ValidBTaggedJetsFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -69,9 +69,9 @@ public:
  */
 class GenElectronsFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -80,9 +80,9 @@ public:
  */
 class GenMuonsFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -91,9 +91,9 @@ public:
  */
 class GenTausFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };
@@ -102,9 +102,9 @@ public:
  */
 class GenTauJetsFilter: public CutRangeFilterBase<KappaTypes> {
 public:
-	
-	typedef typename std::function<double(KappaEvent const&, KappaProduct const&)> double_extractor_lambda;
-	
+
+	typedef typename std::function<double(KappaEvent const&, KappaProduct const&, KappaSettings const&)> double_extractor_lambda;
+
 	std::string GetFilterId() const override;
 	void Init(KappaSettings const& settings) override;
 };

--- a/KappaAnalysis/interface/KappaProduct.h
+++ b/KappaAnalysis/interface/KappaProduct.h
@@ -250,7 +250,34 @@ public:
 	}
 
 	template<class TJet>
+	static typename std::vector<std::shared_ptr<TJet>>::const_iterator GetLastJetAbovePtThreshold(std::vector<std::shared_ptr<TJet>> const& jets, float lowerPtThreshold)
+	{
+		typename std::vector<std::shared_ptr<TJet>>::const_iterator lastJetPos = jets.begin();
+		for (; lastJetPos != jets.end() && (*lastJetPos)->p4.Pt() > lowerPtThreshold; ++lastJetPos) {}
+		return lastJetPos;
+	}
+	template<class TJet>
+	static typename std::vector<std::unique_ptr<TJet>>::const_iterator GetLastJetAbovePtThreshold(std::vector<std::unique_ptr<TJet>> const& jets, float lowerPtThreshold)
+	{
+		typename std::vector<std::unique_ptr<TJet>>::const_iterator lastJetPos = jets.begin();
+		for (; lastJetPos != jets.end() && (*lastJetPos)->p4.Pt() > lowerPtThreshold; ++lastJetPos) {}
+		return lastJetPos;
+	}
+
+	template<class TJet>
 	static size_t GetNJetsAbovePtThreshold(std::vector<TJet*> const& jets, float lowerPtThreshold)
+	{
+		return (KappaProduct::GetLastJetAbovePtThreshold(jets, lowerPtThreshold) - jets.begin());
+	}
+
+	template<class TJet>
+	static size_t GetNJetsAbovePtThreshold(std::vector<std::shared_ptr<TJet>> const& jets, float lowerPtThreshold)
+	{
+		return (KappaProduct::GetLastJetAbovePtThreshold(jets, lowerPtThreshold) - jets.begin());
+	}
+
+	template<class TJet>
+	static size_t GetNJetsAbovePtThreshold(std::vector<std::unique_ptr<TJet>> const& jets, float lowerPtThreshold)
 	{
 		return (KappaProduct::GetLastJetAbovePtThreshold(jets, lowerPtThreshold) - jets.begin());
 	}

--- a/KappaAnalysis/interface/Producers/GenParticleMatchingProducers.h
+++ b/KappaAnalysis/interface/Producers/GenParticleMatchingProducers.h
@@ -15,8 +15,8 @@
 /** Producer for gen matched jets
  *  Required config tags:
  *  - DeltaRMatchingRecoJetGenParticle (default provided)
- *  - InvalidateNonGenParticleMatchingRecoJets (default provided) 
- *  - InvalidateGenParticleMatchingRecoJets (default provided) 
+ *  - InvalidateNonGenParticleMatchingRecoJets (default provided)
+ *  - InvalidateGenParticleMatchingRecoJets (default provided)
  *  - JetMatchingAlgorithm (default provided)
  */
 class RecoJetGenParticleMatchingProducer: public KappaProducerBase
@@ -35,7 +35,7 @@ public:
 		PHYSICS = 2,
 	};
 	static JetMatchingAlgorithm ToJetMatchingAlgorithm(std::string const& jetMatchingAlgorithm);
-	
+
 	std::string GetProducerId() const override;
 
 	void Init(setting_type const& settings) override;
@@ -68,7 +68,7 @@ public:
 	typedef typename KappaTypes::event_type event_type;
 	typedef typename KappaTypes::product_type product_type;
 	typedef typename KappaTypes::setting_type setting_type;
-	
+
 	RecoLeptonGenParticleMatchingProducerBase(std::map<TLepton*, KGenParticle*> product_type::*genParticleMatchedLeptons,
 	                                          std::vector<TLepton>* event_type::*leptons,
 	                                          std::vector<TLepton*> product_type::*validLeptons,
@@ -95,11 +95,11 @@ public:
 	void Init(setting_type const& settings) override
 	{
 		KappaProducerBase::Init(settings);
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("ratioGenParticleMatched", [](event_type const & event, product_type const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("ratioGenParticleMatched", [](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return product.m_ratioGenParticleMatched;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genParticleMatchDeltaR", [](event_type const & event, product_type const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genParticleMatchDeltaR", [](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return product.m_genParticleMatchDeltaR;
 		});
@@ -199,7 +199,7 @@ public:
 		{
 			product.m_genParticleMatchDeltaR = DefaultValues::UndefinedFloat;
 		}
-		
+
 		product.m_ratioGenParticleMatched = ratioGenParticleMatched;
 	}
 
@@ -215,7 +215,7 @@ private:
 	bool (setting_type::*GetInvalidateNonGenParticleMatchingLeptons)(void) const;
 	bool (setting_type::*GetInvalidateGenParticleMatchingLeptons)(void) const;
 	bool (setting_type::*GetRecoLeptonMatchingGenParticleMatchAllLeptons)(void) const;
-	
+
 	std::map<size_t, std::vector<std::string> > m_leptonTriggerFiltersByIndex;
 	std::map<std::string, std::vector<std::string> > m_leptonTriggerFiltersByHltName;
 
@@ -234,7 +234,7 @@ class RecoElectronGenParticleMatchingProducer: public RecoLeptonGenParticleMatch
 {
 
 public:
-	
+
 	std::string GetProducerId() const override;
 
 	RecoElectronGenParticleMatchingProducer();
@@ -254,9 +254,9 @@ class RecoMuonGenParticleMatchingProducer: public RecoLeptonGenParticleMatchingP
 {
 
 public:
-	
+
 	std::string GetProducerId() const override;
-	
+
 	RecoMuonGenParticleMatchingProducer();
 
 };
@@ -274,9 +274,9 @@ class RecoTauGenParticleMatchingProducer: public RecoLeptonGenParticleMatchingPr
 {
 
 public:
-	
+
 	std::string GetProducerId() const override;
-	
+
 	RecoTauGenParticleMatchingProducer();
 
 };

--- a/KappaAnalysis/interface/Producers/GenTauMatchingProducers.h
+++ b/KappaAnalysis/interface/Producers/GenTauMatchingProducers.h
@@ -18,7 +18,7 @@ class GenTauMatchingProducerBase: public ProducerBase<KappaTypes>
 {
 
 public:
-	
+
 	enum class TauDecayMode : int
 	{
 		NONE = -1,
@@ -30,7 +30,7 @@ public:
 	typedef typename KappaTypes::event_type event_type;
 	typedef typename KappaTypes::product_type product_type;
 	typedef typename KappaTypes::setting_type setting_type;
-	
+
 	GenTauMatchingProducerBase(std::map<TValidObject*, KGenTau*> product_type::*genTauMatchedObjects, //changed to KGenParticle from const KDataLV
 	                           std::vector<TValidObject>* event_type::*objects,
 	                           std::vector<TValidObject*> product_type::*validObjects,
@@ -54,14 +54,14 @@ public:
 	{
 	}
 
-	void Init(setting_type const& settings) override 
+	void Init(setting_type const& settings) override
 	{
 		ProducerBase<KappaTypes>::Init(settings);
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("ratioGenTauMatched", [](event_type const & event, product_type const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("ratioGenTauMatched", [](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return product.m_ratioGenTauMatched;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genTauMatchTauDeltaR", [](event_type const & event, product_type const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genTauMatchTauDeltaR", [](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return product.m_genTauMatchDeltaR;
 		});
@@ -71,9 +71,9 @@ public:
 	             setting_type const& settings) const override
 	{
 		double ratioGenTauMatched = 0;
-		
+
 		assert(event.m_genTaus);
-		
+
 		if ((settings.*GetDeltaRMatchingRecoObjectGenTau)() > 0.0f)
 		{
 			// choose valid objects or all objects for matching
@@ -107,10 +107,10 @@ public:
 				bool objectMatched = false;
 				float deltaR = 0;
 				float deltaRmin = std::numeric_limits<float>::max();
-				
+
 				// loop over all genTaus
-				for (typename std::vector<KGenTau>::iterator genTau = event.m_genTaus->begin(); 
-					genTau != event.m_genTaus->end(); ++genTau) 
+				for (typename std::vector<KGenTau>::iterator genTau = event.m_genTaus->begin();
+					genTau != event.m_genTaus->end(); ++genTau)
 				{
 					// if configured: only use genTaus that will decay into comparable particles
 					if (!(settings.*GetMatchGenTauDecayMode)() || ((settings.*GetMatchGenTauDecayMode)() && MatchDecayMode(*genTau, tauDecayMode)))
@@ -157,7 +157,7 @@ public:
 		}
 		product.m_ratioGenTauMatched = ratioGenTauMatched;
 	}
-	
+
 	virtual bool MatchDecayMode(KGenTau const &genTau, TauDecayMode tauDecayMode) const
 	{
 		bool decayModeMatched = (((tauDecayMode == TauDecayMode::E) && genTau.isElectronicDecay()) ||
@@ -165,7 +165,7 @@ public:
 		                         ((tauDecayMode == TauDecayMode::T) && genTau.isHadronicDecay()));
 		return decayModeMatched;
 	}
-	
+
 private:
 	std::map<TValidObject*, KGenTau*> product_type::*m_genTauMatchedObjects; //changed to KGenParticle from const KDataLV
 	std::vector<TValidObject>* event_type::*m_objects;
@@ -190,7 +190,7 @@ class RecoElectronGenTauMatchingProducer: public GenTauMatchingProducerBase<KEle
 {
 
 public:
-	
+
 	std::string GetProducerId() const override;
 
 	RecoElectronGenTauMatchingProducer();
@@ -208,9 +208,9 @@ class RecoMuonGenTauMatchingProducer: public GenTauMatchingProducerBase<KMuon>
 {
 
 public:
-	
+
 	std::string GetProducerId() const override;
-	
+
 	RecoMuonGenTauMatchingProducer();
 
 };
@@ -226,9 +226,9 @@ class RecoTauGenTauMatchingProducer: public GenTauMatchingProducerBase<KTau>
 {
 
 public:
-	
+
 	std::string GetProducerId() const override;
-	
+
 	RecoTauGenTauMatchingProducer();
 
 };

--- a/KappaAnalysis/interface/Producers/JetCorrectionsProducer.h
+++ b/KappaAnalysis/interface/Producers/JetCorrectionsProducer.h
@@ -24,22 +24,22 @@
 #include "TRandom3.h"
 
 /**
-	 \brief Producer for jet corrections (mainly JEC)
+     \brief Producer for jet corrections (mainly JEC)
 
-	 Required config tags:
-	 - JetEnergyCorrectionParameters (files containing the correction parameters in the right order)
-	 - JetEnergyCorrectionUncertaintyParameters (default: empty)
-	 - JetEnergyCorrectionUncertaintySource (default "")
-	 - JetEnergyCorrectionUncertaintyShift (default 0.0)
+     Required config tags:
+     - JetEnergyCorrectionParameters (files containing the correction parameters in the right order)
+     - JetEnergyCorrectionUncertaintyParameters (default: empty)
+     - JetEnergyCorrectionUncertaintySource (default "")
+     - JetEnergyCorrectionUncertaintyShift (default 0.0)
 
-	 Required packages (unfortunately, nobody knows a tag):
-	 git cms-addpkg CondFormats/JetMETObjects
+     Required packages (unfortunately, nobody knows a tag):
+     git cms-addpkg CondFormats/JetMETObjects
 
-	 Documentation:
-	 https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#JetEnCorFWLite
+     Documentation:
+     https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#JetEnCorFWLite
 
-	 TODO: the code can be moved to a .cc file, if there are no external users using the TJet templated
-				 version
+     TODO: the code can be moved to a .cc file, if there are no external users using the TJet templated
+                 version
 */
 
 
@@ -47,273 +47,274 @@ template<class TJet>
 class JetCorrectionsProducerBase: public KappaProducerBase
 {
 
-	public:
+    public:
 
-		JetCorrectionsProducerBase(std::vector<TJet>* KappaEvent::*jets,
-			std::vector<std::shared_ptr<TJet> > KappaProduct::*correctedJets) :
-			KappaProducerBase(),
-			m_basicJetsMember(jets),
-			m_correctedJetsMember(correctedJets)
-		{
-		}
+        JetCorrectionsProducerBase(std::vector<TJet>* KappaEvent::*jets,
+            std::vector<std::shared_ptr<TJet> > KappaProduct::*correctedJets) :
+            KappaProducerBase(),
+            m_basicJetsMember(jets),
+            m_correctedJetsMember(correctedJets)
+        {
+        }
 
-		~JetCorrectionsProducerBase()
-		{
-			delete factorizedJetCorrector;
-		}
+        virtual ~JetCorrectionsProducerBase()
+        {
+            delete factorizedJetCorrector;
+            delete jetCorrectionUncertainty;
+            JetCorParMap.clear();
+            JetUncMap.clear();
+        }
 
-		void Init(KappaSettings const& settings) override
-		{
-			KappaProducerBase::Init(settings);
+        void Init(KappaSettings const& settings) override
+        {
+            KappaProducerBase::Init(settings);
 
-			// load correction parameters
-			LOG(DEBUG) << "\tLoading JetCorrectorParameters from files...";
-			std::vector<JetCorrectorParameters> jecParameters;
-			for (std::vector<std::string>::const_iterator jecParametersFile = settings.GetJetEnergyCorrectionParameters().begin();
-					 jecParametersFile != settings.GetJetEnergyCorrectionParameters().end(); ++jecParametersFile)
-			{
-				jecParameters.push_back(JetCorrectorParameters(*jecParametersFile));
-				LOG(DEBUG) << "\t\t" << *jecParametersFile;
-			}
-			if (jecParameters.size() > 0)
-			{
-				factorizedJetCorrector = new FactorizedJetCorrector(jecParameters);
-			}
+            // load correction parameters
+            LOG(DEBUG) << "\tLoading JetCorrectorParameters from files...";
+            std::vector<JetCorrectorParameters> jecParameters;
+            for (std::vector<std::string>::const_iterator jecParametersFile = settings.GetJetEnergyCorrectionParameters().begin();
+                     jecParametersFile != settings.GetJetEnergyCorrectionParameters().end(); ++jecParametersFile)
+            {
+                jecParameters.push_back(JetCorrectorParameters(*jecParametersFile));
+                LOG(DEBUG) << "\t\t" << *jecParametersFile;
+            }
+            if (jecParameters.size() > 0)
+            {
+                factorizedJetCorrector = new FactorizedJetCorrector(jecParameters);
+            }
 
-			// initialise uncertainty calculation
-			LOG(DEBUG) << "\tLoading JetCorrectionUncertainty from files...";
-			if ((! settings.GetJetEnergyCorrectionUncertaintyParameters().empty()) &&
-				(settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0))
-			{
-				JetCorrectorParameters* jecUncertaintyParameters = nullptr;
-				if (!settings.GetJetEnergyCorrectionUncertaintySource().empty()) {
-					jecUncertaintyParameters = new JetCorrectorParameters(
-						settings.GetJetEnergyCorrectionUncertaintyParameters(),
-						settings.GetJetEnergyCorrectionUncertaintySource()
-					);
-				}
-				else {
-					jecUncertaintyParameters = new JetCorrectorParameters(settings.GetJetEnergyCorrectionUncertaintyParameters());
-				}
-				if ((!jecUncertaintyParameters->isValid()) || (jecUncertaintyParameters->size() == 0))
-					LOG(FATAL) << "Invalid definition " << settings.GetJetEnergyCorrectionUncertaintySource()
-						 << " in file " << settings.GetJetEnergyCorrectionUncertaintyParameters();
-				jetCorrectionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
-				LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintySource();
-				LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintyParameters();
-			}
+            // initialise uncertainty calculation
+            LOG(DEBUG) << "\tLoading JetCorrectionUncertainty from files...";
+            if ((! settings.GetJetEnergyCorrectionUncertaintyParameters().empty()) &&
+                (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0))
+            {
+                JetCorrectorParameters* jecUncertaintyParameters = nullptr;
+                if (!settings.GetJetEnergyCorrectionUncertaintySource().empty()) {
+                    jecUncertaintyParameters = new JetCorrectorParameters(
+                        settings.GetJetEnergyCorrectionUncertaintyParameters(),
+                        settings.GetJetEnergyCorrectionUncertaintySource()
+                    );
+                }
+                else {
+                    jecUncertaintyParameters = new JetCorrectorParameters(settings.GetJetEnergyCorrectionUncertaintyParameters());
+                }
+                if ((!jecUncertaintyParameters->isValid()) || (jecUncertaintyParameters->size() == 0))
+                    LOG(FATAL) << "Invalid definition " << settings.GetJetEnergyCorrectionUncertaintySource()
+                         << " in file " << settings.GetJetEnergyCorrectionUncertaintyParameters();
+                jetCorrectionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
+                delete jecUncertaintyParameters;
+                LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintySource();
+                LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintyParameters();
+            }
 
-			uncertaintyFile = settings.GetJetEnergyCorrectionSplitUncertaintyParameters();
-			individualUncertainties = settings.GetJetEnergyCorrectionSplitUncertaintyParameterNames();
+            uncertaintyFile = settings.GetJetEnergyCorrectionSplitUncertaintyParameters();
+            individualUncertainties = settings.GetJetEnergyCorrectionSplitUncertaintyParameterNames();
 
-			// make sure the necessary parameters are configured
-			assert(uncertaintyFile != "");
-			if (settings.GetUseGroupedJetEnergyCorrectionUncertainty()) assert(individualUncertainties.size() > 0);
+            // make sure the necessary parameters are configured
+            assert(uncertaintyFile != "");
+            if (settings.GetUseGroupedJetEnergyCorrectionUncertainty()) assert(individualUncertainties.size() > 0);
 
-			for (auto const& uncertainty : individualUncertainties)
-			{
-				// only do string comparison once per uncertainty
-				KappaEnumTypes::JetEnergyUncertaintyShiftName individualUncertainty = KappaEnumTypes::ToJetEnergyUncertaintyShiftName(uncertainty);
-				if (individualUncertainty == KappaEnumTypes::JetEnergyUncertaintyShiftName::NONE)
-								continue;
-				individualUncertaintyEnums.push_back(individualUncertainty);
+            for (auto const& uncertainty : individualUncertainties)
+            {
+                // only do string comparison once per uncertainty
+                KappaEnumTypes::JetEnergyUncertaintyShiftName individualUncertainty = KappaEnumTypes::ToJetEnergyUncertaintyShiftName(uncertainty);
+                if (individualUncertainty == KappaEnumTypes::JetEnergyUncertaintyShiftName::NONE)
+                                continue;
+                individualUncertaintyEnums.push_back(individualUncertainty);
 
-				// create uncertainty map (only if shifts are to be applied)
-				if (settings.GetUseGroupedJetEnergyCorrectionUncertainty()
-					&& settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0
-					&& individualUncertainty != KappaEnumTypes::JetEnergyUncertaintyShiftName::Closure)
-				{
-					JetCorrectorParameters const * jetCorPar = new JetCorrectorParameters(uncertaintyFile, uncertainty);
-					JetCorParMap[individualUncertainty] = jetCorPar;
+                // create uncertainty map (only if shifts are to be applied)
+                if (settings.GetUseGroupedJetEnergyCorrectionUncertainty()
+                    && settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0
+                    && individualUncertainty != KappaEnumTypes::JetEnergyUncertaintyShiftName::Closure)
+                {
+                    JetCorParMap[individualUncertainty] = std::make_unique<const JetCorrectorParameters>(uncertaintyFile, uncertainty);
+                    JetUncMap[individualUncertainty] = std::make_unique<JetCorrectionUncertainty>(*JetCorParMap[individualUncertainty]);
+                }
+            }
+            assert(settings.GetJetEnergyResolutionSource() != "");
+            assert(settings.GetJetEnergyResolutionSFSource() != "");
+            m_jetResolution.reset(new JME::JetResolution(settings.GetJetEnergyResolutionSource()));
+            m_jetResolutionScaleFactor.reset(new JME::JetResolutionScaleFactor(settings.GetJetEnergyResolutionSFSource()));
+            if(settings.GetJetEnergyResolutionUncertaintyShift()==0.0) JER_shift = Variation::NOMINAL;
+            else if(settings.GetJetEnergyResolutionUncertaintyShift()==1.0) JER_shift = Variation::UP;
+            else if(settings.GetJetEnergyResolutionUncertaintyShift()==-1.0) JER_shift = Variation::DOWN;
+            else LOG(FATAL) << "Invalid definition of JetEnergyResolutionUncertaintyShift: " << settings.GetJetEnergyResolutionUncertaintyShift();
+        }
 
-					JetCorrectionUncertainty * jecUnc(new JetCorrectionUncertainty(*JetCorParMap[individualUncertainty]));
-					JetUncMap[individualUncertainty] = jecUnc;
-				}
-			}
-			assert(settings.GetJetEnergyResolutionSource() != "");
-			assert(settings.GetJetEnergyResolutionSFSource() != "");
-			m_jetResolution.reset(new JME::JetResolution(settings.GetJetEnergyResolutionSource()));
-			m_jetResolutionScaleFactor.reset(new JME::JetResolutionScaleFactor(settings.GetJetEnergyResolutionSFSource()));
-			if(settings.GetJetEnergyResolutionUncertaintyShift()==0.0) JER_shift = Variation::NOMINAL;
-			else if(settings.GetJetEnergyResolutionUncertaintyShift()==1.0) JER_shift = Variation::UP;
-			else if(settings.GetJetEnergyResolutionUncertaintyShift()==-1.0) JER_shift = Variation::DOWN;
-			else LOG(FATAL) << "Invalid definition of JetEnergyResolutionUncertaintyShift: " << settings.GetJetEnergyResolutionUncertaintyShift();
-		}
+        void Produce(KappaEvent const& event, KappaProduct& product,
+                                                 KappaSettings const& settings) const override
+        {
+            LOG(DEBUG) << "\nStarting " << this->GetProducerId() <<  ". Consider pipeline: " << settings.GetRootFileFolder();
+            assert((event.*m_basicJetsMember));
+            assert(event.m_pileupDensity);
+            assert(event.m_vertexSummary);
+            // create a copy of all jets in the event (first temporarily for the JEC)
+            (product.*m_correctedJetsMember).clear();
+            std::vector<TJet> correctJetsForJecTools((event.*m_basicJetsMember)->size());
+            size_t jetIndex = 0;
+            for (typename std::vector<TJet>::const_iterator jet = (event.*m_basicJetsMember)->begin();
+                 jet != (event.*m_basicJetsMember)->end(); ++jet)
+            {
+                correctJetsForJecTools[jetIndex] = *jet;
+                ++jetIndex;
+            }
 
-		void Produce(KappaEvent const& event, KappaProduct& product,
-												 KappaSettings const& settings) const override
-		{
-			LOG(DEBUG) << "\nStarting " << this->GetProducerId() <<  ". Consider pipeline: " << settings.GetRootFileFolder();
-			assert((event.*m_basicJetsMember));
-			assert(event.m_pileupDensity);
-			assert(event.m_vertexSummary);
-			// create a copy of all jets in the event (first temporarily for the JEC)
-			(product.*m_correctedJetsMember).clear();
-			std::vector<TJet> correctJetsForJecTools((event.*m_basicJetsMember)->size());
-			size_t jetIndex = 0;
-			for (typename std::vector<TJet>::const_iterator jet = (event.*m_basicJetsMember)->begin();
-				 jet != (event.*m_basicJetsMember)->end(); ++jet)
-			{
-				correctJetsForJecTools[jetIndex] = *jet;
-				++jetIndex;
-			}
+            if (settings.GetUseGroupedJetEnergyCorrectionUncertainty() && settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
+            {
+                // run over all jets
+                for (typename std::vector<TJet>::iterator jet = correctJetsForJecTools.begin();
+                     jet != correctJetsForJecTools.end(); ++jet)
+                {
+                    LOG(DEBUG) << "\tConsidering jet with p4 = " << jet->p4;
+                    // shift corrected jets
+                    double grouped_unc = 0.0;
+                    if(individualUncertaintyEnums.size() == 1)
+                    {
+                        if (std::abs(jet->p4.Eta()) < 5.2 && jet->p4.Pt() > 9.)
+                        {
+                            auto const& uncertainty = individualUncertaintyEnums.at(0);
+                            JetUncMap.at(uncertainty)->setJetEta(jet->p4.Eta());
+                            JetUncMap.at(uncertainty)->setJetPt(jet->p4.Pt());
+                            grouped_unc = JetUncMap.at(uncertainty)->getUncertainty(true);
+                        }
+                    }
+                    else
+                    {
+                        for (auto const& uncertainty : individualUncertaintyEnums)
+                        {
+                            double unc = 0.0;
 
-			if (settings.GetUseGroupedJetEnergyCorrectionUncertainty() && settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
-			{
-				// run over all jets
-				for (typename std::vector<TJet>::iterator jet = correctJetsForJecTools.begin();
-					 jet != correctJetsForJecTools.end(); ++jet)
-				{
-					LOG(DEBUG) << "\tConsidering jet with p4 = " << jet->p4;
-					// shift corrected jets
-					double grouped_unc = 0.0;
-					if(individualUncertaintyEnums.size() == 1)
-					{
-						if (std::abs(jet->p4.Eta()) < 5.2 && jet->p4.Pt() > 9.)
-						{
-							auto const& uncertainty = individualUncertaintyEnums.at(0);
-							JetUncMap.at(uncertainty)->setJetEta(jet->p4.Eta());
-							JetUncMap.at(uncertainty)->setJetPt(jet->p4.Pt());
-							grouped_unc = JetUncMap.at(uncertainty)->getUncertainty(true);
-						}
-					}
-					else
-					{
-						for (auto const& uncertainty : individualUncertaintyEnums)
-						{
-							double unc = 0.0;
+                            if (std::abs(jet->p4.Eta()) < 5.2 && jet->p4.Pt() > 9.)
+                            {
+                                JetUncMap.at(uncertainty)->setJetEta(jet->p4.Eta());
+                                JetUncMap.at(uncertainty)->setJetPt(jet->p4.Pt());
+                                unc = JetUncMap.at(uncertainty)->getUncertainty(true);
+                                grouped_unc += unc * unc;
+                            }
+                        }
+                        grouped_unc = sqrt(grouped_unc);
+                    }
+                    if (jet->p4.Pt() * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift())>15.0){ // requirement for type I corrections
+                        product.m_MET_shift.p4 += jet->p4;
+                        jet->p4 = jet->p4 * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift());
+                        product.m_MET_shift.p4 -= jet->p4;
+                    } else {
+                        jet->p4 = jet->p4 * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift());
+                    }
+                    LOG(DEBUG) << "\tGrouped uncertainty applied: " << grouped_unc << " shifted p4: " << jet->p4;
+                }
+            }
+            else if (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
+            {
+                // apply jet energy corrections and uncertainty shift (if uncertainties are not to be splitted into individual contributions)
+                float shift = settings.GetJetEnergyCorrectionSplitUncertainty() ? 0.0 : settings.GetJetEnergyCorrectionUncertaintyShift();
+                correctJets(&correctJetsForJecTools, factorizedJetCorrector, jetCorrectionUncertainty,
+                            event.m_pileupDensity->rho, event.m_vertexSummary->nVertices, -1,
+                            shift);
+            }
+            // apply JER smearing
+            for (typename std::vector<TJet>::iterator jet = correctJetsForJecTools.begin();
+                                             jet != correctJetsForJecTools.end(); ++jet)
+            {
+                randm.SetSeed(static_cast<int>((jet->p4.Eta() + 5) * 1000) * 1000 + static_cast<int>((jet->p4.Phi() + 4) * 1000) + 10000);
+                double jetResolution = m_jetResolution->getResolution({
+                        {JME::Binning::JetPt, jet->p4.Pt()},
+                        {JME::Binning::JetEta, jet->p4.Eta()},
+                        {JME::Binning::Rho, event.m_pileupDensity->rho}
+                });
+                double jetResolutionScaleFactor = m_jetResolutionScaleFactor->getScaleFactor({
+                        {JME::Binning::JetPt, jet->p4.Pt()},
+                        {JME::Binning::JetEta, jet->p4.Eta()}
+                }, JER_shift);
+                double shift = randm.Gaus(0, jetResolution) * std::sqrt(std::max(jetResolutionScaleFactor * jetResolutionScaleFactor - 1, 0.0));
+                if (shift < -1.0) shift = -1.0;
+                if ((jet->p4*(1.0+shift)).Pt()>15.0) product.m_MET_shift.p4 -= jet->p4*shift; // requirement for type I corrections
+                jet->p4 *= 1.0 + shift;
+            }
+            // create the shared pointers to store in the product
+            (product.*m_correctedJetsMember).clear();
+            (product.*m_correctedJetsMember).resize(correctJetsForJecTools.size());
+            jetIndex = 0;
+            for (typename std::vector<TJet>::const_iterator jet = correctJetsForJecTools.begin();
+                 jet != correctJetsForJecTools.end(); ++jet)
+            {
+                (product.*m_correctedJetsMember)[jetIndex] = std::shared_ptr<TJet>(std::make_shared<TJet>(*jet));
+                product.m_originalJets[(product.*m_correctedJetsMember)[jetIndex].get()] = &(*jet);
+                ++jetIndex;
+            }
 
-							if (std::abs(jet->p4.Eta()) < 5.2 && jet->p4.Pt() > 9.)
-							{
-								JetUncMap.at(uncertainty)->setJetEta(jet->p4.Eta());
-								JetUncMap.at(uncertainty)->setJetPt(jet->p4.Pt());
-								unc = JetUncMap.at(uncertainty)->getUncertainty(true);
-								grouped_unc += unc * unc;
-							}
-						}
-						grouped_unc = sqrt(grouped_unc);
-					}
-					if (jet->p4.Pt() * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift())>15.0){ // requirement for type I corrections
-						product.m_MET_shift.p4 += jet->p4;
-						jet->p4 = jet->p4 * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift());
-						product.m_MET_shift.p4 -= jet->p4;
-					} else {
-						jet->p4 = jet->p4 * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift());
-					}
-					LOG(DEBUG) << "\tGrouped uncertainty applied: " << grouped_unc << " shifted p4: " << jet->p4;
-				}
-			}
-			else if (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
-			{
-				// apply jet energy corrections and uncertainty shift (if uncertainties are not to be splitted into individual contributions)
-				float shift = settings.GetJetEnergyCorrectionSplitUncertainty() ? 0.0 : settings.GetJetEnergyCorrectionUncertaintyShift();
-				correctJets(&correctJetsForJecTools, factorizedJetCorrector, jetCorrectionUncertainty,
-							event.m_pileupDensity->rho, event.m_vertexSummary->nVertices, -1,
-							shift);
-			}
-			// apply JER smearing
-			for (typename std::vector<TJet>::iterator jet = correctJetsForJecTools.begin();
-											 jet != correctJetsForJecTools.end(); ++jet)
-			{
-				randm.SetSeed(static_cast<int>((jet->p4.Eta() + 5) * 1000) * 1000 + static_cast<int>((jet->p4.Phi() + 4) * 1000) + 10000);
-				double jetResolution = m_jetResolution->getResolution({
-						{JME::Binning::JetPt, jet->p4.Pt()},
-						{JME::Binning::JetEta, jet->p4.Eta()},
-						{JME::Binning::Rho, event.m_pileupDensity->rho}
-				});
-				double jetResolutionScaleFactor = m_jetResolutionScaleFactor->getScaleFactor({
-						{JME::Binning::JetPt, jet->p4.Pt()},
-						{JME::Binning::JetEta, jet->p4.Eta()}
-				}, JER_shift);
-				double shift = randm.Gaus(0, jetResolution) * std::sqrt(std::max(jetResolutionScaleFactor * jetResolutionScaleFactor - 1, 0.0));
-				if (shift < -1.0) shift = -1.0;
-				if ((jet->p4*(1.0+shift)).Pt()>15.0) product.m_MET_shift.p4 -= jet->p4*shift; // requirement for type I corrections
-				jet->p4 *= 1.0 + shift;
-			}
-			// create the shared pointers to store in the product
-			(product.*m_correctedJetsMember).clear();
-			(product.*m_correctedJetsMember).resize(correctJetsForJecTools.size());
-			jetIndex = 0;
-			for (typename std::vector<TJet>::const_iterator jet = correctJetsForJecTools.begin();
-				 jet != correctJetsForJecTools.end(); ++jet)
-			{
-				(product.*m_correctedJetsMember)[jetIndex] = std::shared_ptr<TJet>(new TJet(*jet));
-				product.m_originalJets[(product.*m_correctedJetsMember)[jetIndex].get()] = &(*jet);
-				++jetIndex;
-			}
+            // perform additional corrections on copied jets
+            for (typename std::vector<std::shared_ptr<TJet> >::iterator jet = (product.*m_correctedJetsMember).begin();
+                 jet != (product.*m_correctedJetsMember).end(); ++jet)
+            {
+                AdditionalCorrections(jet->get(), event, product, settings);
+                LOG(DEBUG) << "\tFinal jet p4: " << (*jet)->p4;
+            }
 
-			// perform additional corrections on copied jets
-			for (typename std::vector<std::shared_ptr<TJet> >::iterator jet = (product.*m_correctedJetsMember).begin();
-				 jet != (product.*m_correctedJetsMember).end(); ++jet)
-			{
-				AdditionalCorrections(jet->get(), event, product, settings);
-				LOG(DEBUG) << "\tFinal jet p4: " << (*jet)->p4;
-			}
-
-			// sort vectors of corrected jets by pt
-			std::sort((product.*m_correctedJetsMember).begin(), (product.*m_correctedJetsMember).end(),
-				[](std::shared_ptr<TJet> jet1, std::shared_ptr<TJet> jet2) -> bool
-				{ return jet1->p4.Pt() > jet2->p4.Pt(); });
-		}
-
-
-	protected:
-		// Can be overwritten for analysis-specific use cases
-		virtual void AdditionalCorrections(TJet* jet, KappaEvent const& event,
-			KappaProduct& product, KappaSettings const& settings) const
-		{
-		}
+            // sort vectors of corrected jets by pt
+            std::sort((product.*m_correctedJetsMember).begin(), (product.*m_correctedJetsMember).end(),
+                [](std::shared_ptr<TJet> jet1, std::shared_ptr<TJet> jet2) -> bool
+                { return jet1->p4.Pt() > jet2->p4.Pt(); });
+        }
 
 
-	private:
-		std::vector<TJet>* KappaEvent::*m_basicJetsMember;
-		std::vector<std::shared_ptr<TJet> > KappaProduct::*m_correctedJetsMember;
+    protected:
+        // Can be overwritten for analysis-specific use cases
+        virtual void AdditionalCorrections(TJet* jet, KappaEvent const& event,
+            KappaProduct& product, KappaSettings const& settings) const
+        {
+        }
 
-		std::string uncertaintyFile;
-		std::vector<std::string> individualUncertainties;
-		std::vector<KappaEnumTypes::JetEnergyUncertaintyShiftName> individualUncertaintyEnums;
 
-		std::map<KappaEnumTypes::JetEnergyUncertaintyShiftName, JetCorrectorParameters const*> JetCorParMap;
-		std::map<KappaEnumTypes::JetEnergyUncertaintyShiftName, JetCorrectionUncertainty *> JetUncMap;
+    private:
+        std::vector<TJet>* KappaEvent::*m_basicJetsMember;
+        std::vector<std::shared_ptr<TJet> > KappaProduct::*m_correctedJetsMember;
 
-		FactorizedJetCorrector* factorizedJetCorrector = nullptr;
-		JetCorrectionUncertainty* jetCorrectionUncertainty = nullptr;
+        std::string uncertaintyFile;
+        std::vector<std::string> individualUncertainties;
+        std::vector<KappaEnumTypes::JetEnergyUncertaintyShiftName> individualUncertaintyEnums;
 
-		mutable TRandom3 randm = TRandom3(0);
-		std::unique_ptr<JME::JetResolution> m_jetResolution;
-		std::unique_ptr<JME::JetResolutionScaleFactor> m_jetResolutionScaleFactor;
-		Variation JER_shift;
+        std::map<KappaEnumTypes::JetEnergyUncertaintyShiftName, std::unique_ptr<const JetCorrectorParameters> > JetCorParMap;
+        std::map<KappaEnumTypes::JetEnergyUncertaintyShiftName, std::unique_ptr<JetCorrectionUncertainty> > JetUncMap;
+
+        FactorizedJetCorrector* factorizedJetCorrector = nullptr;
+        JetCorrectionUncertainty* jetCorrectionUncertainty = nullptr;
+
+        mutable TRandom3 randm = TRandom3(0);
+        std::unique_ptr<JME::JetResolution> m_jetResolution;
+        std::unique_ptr<JME::JetResolutionScaleFactor> m_jetResolutionScaleFactor;
+        Variation JER_shift;
 };
 
 
 
 /**
-	 \brief Producer for Jet Energy Correction (JEC)
+     \brief Producer for Jet Energy Correction (JEC)
 
-	 Operates on the vector event.m_basicJets and product::m_correctedJets.
+     Operates on the vector event.m_basicJets and product::m_correctedJets.
 */
 class JetCorrectionsProducer: public JetCorrectionsProducerBase<KBasicJet>
 {
-	public:
-		JetCorrectionsProducer();
+    public:
+        JetCorrectionsProducer();
 
-		std::string GetProducerId() const override;
+        std::string GetProducerId() const override;
 };
 
 
 
 /**
-	 \brief Producer for Jet Energy Correction (JEC)
+     \brief Producer for Jet Energy Correction (JEC)
 
-	 Operates on the vector event.m_tjets and product::m_correctedTaggedJets.
+     Operates on the vector event.m_tjets and product::m_correctedTaggedJets.
 */
 class TaggedJetCorrectionsProducer: public JetCorrectionsProducerBase<KJet>
 {
-	public:
+    public:
 
-		TaggedJetCorrectionsProducer();
+        TaggedJetCorrectionsProducer();
 
-		std::string GetProducerId() const override;
+        std::string GetProducerId() const override;
 };
 
 

--- a/KappaAnalysis/interface/Producers/JetCorrectionsProducer.h
+++ b/KappaAnalysis/interface/Producers/JetCorrectionsProducer.h
@@ -24,22 +24,22 @@
 #include "TRandom3.h"
 
 /**
-   \brief Producer for jet corrections (mainly JEC)
+	 \brief Producer for jet corrections (mainly JEC)
 
-   Required config tags:
-   - JetEnergyCorrectionParameters (files containing the correction parameters in the right order)
-   - JetEnergyCorrectionUncertaintyParameters (default: empty)
-   - JetEnergyCorrectionUncertaintySource (default "")
-   - JetEnergyCorrectionUncertaintyShift (default 0.0)
+	 Required config tags:
+	 - JetEnergyCorrectionParameters (files containing the correction parameters in the right order)
+	 - JetEnergyCorrectionUncertaintyParameters (default: empty)
+	 - JetEnergyCorrectionUncertaintySource (default "")
+	 - JetEnergyCorrectionUncertaintyShift (default 0.0)
 
-   Required packages (unfortunately, nobody knows a tag):
-   git cms-addpkg CondFormats/JetMETObjects
+	 Required packages (unfortunately, nobody knows a tag):
+	 git cms-addpkg CondFormats/JetMETObjects
 
-   Documentation:
-   https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#JetEnCorFWLite
+	 Documentation:
+	 https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#JetEnCorFWLite
 
-   TODO: the code can be moved to a .cc file, if there are no external users using the TJet templated
-		 version
+	 TODO: the code can be moved to a .cc file, if there are no external users using the TJet templated
+				 version
 */
 
 
@@ -47,238 +47,237 @@ template<class TJet>
 class JetCorrectionsProducerBase: public KappaProducerBase
 {
 
-public:
+	public:
 
-	JetCorrectionsProducerBase(std::vector<TJet>* KappaEvent::*jets,
-							   std::vector<std::shared_ptr<TJet> > KappaProduct::*correctedJets) :
-		KappaProducerBase(),
-		m_basicJetsMember(jets),
-		m_correctedJetsMember(correctedJets)
-	{
-	}
-
-	~JetCorrectionsProducerBase()
-	{
-		delete factorizedJetCorrector;
-	}
-
-	void Init(KappaSettings const& settings) override
-	{
-		KappaProducerBase::Init(settings);
-
-		// load correction parameters
-		LOG(DEBUG) << "\tLoading JetCorrectorParameters from files...";
-		std::vector<JetCorrectorParameters> jecParameters;
-		for (std::vector<std::string>::const_iterator jecParametersFile = settings.GetJetEnergyCorrectionParameters().begin();
-			 jecParametersFile != settings.GetJetEnergyCorrectionParameters().end(); ++jecParametersFile)
+		JetCorrectionsProducerBase(std::vector<TJet>* KappaEvent::*jets,
+			std::vector<std::shared_ptr<TJet> > KappaProduct::*correctedJets) :
+			KappaProducerBase(),
+			m_basicJetsMember(jets),
+			m_correctedJetsMember(correctedJets)
 		{
-			jecParameters.push_back(JetCorrectorParameters(*jecParametersFile));
-			LOG(DEBUG) << "\t\t" << *jecParametersFile;
-		}
-		if (jecParameters.size() > 0)
-		{
-			factorizedJetCorrector = new FactorizedJetCorrector(jecParameters);
 		}
 
-		// initialise uncertainty calculation
-		LOG(DEBUG) << "\tLoading JetCorrectionUncertainty from files...";
-		if ((! settings.GetJetEnergyCorrectionUncertaintyParameters().empty()) &&
-			(settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0))
+		~JetCorrectionsProducerBase()
 		{
-			JetCorrectorParameters* jecUncertaintyParameters = nullptr;
-			if (!settings.GetJetEnergyCorrectionUncertaintySource().empty()) {
-				jecUncertaintyParameters = new JetCorrectorParameters(
+			delete factorizedJetCorrector;
+		}
+
+		void Init(KappaSettings const& settings) override
+		{
+			KappaProducerBase::Init(settings);
+
+			// load correction parameters
+			LOG(DEBUG) << "\tLoading JetCorrectorParameters from files...";
+			std::vector<JetCorrectorParameters> jecParameters;
+			for (std::vector<std::string>::const_iterator jecParametersFile = settings.GetJetEnergyCorrectionParameters().begin();
+					 jecParametersFile != settings.GetJetEnergyCorrectionParameters().end(); ++jecParametersFile)
+			{
+				jecParameters.push_back(JetCorrectorParameters(*jecParametersFile));
+				LOG(DEBUG) << "\t\t" << *jecParametersFile;
+			}
+			if (jecParameters.size() > 0)
+			{
+				factorizedJetCorrector = new FactorizedJetCorrector(jecParameters);
+			}
+
+			// initialise uncertainty calculation
+			LOG(DEBUG) << "\tLoading JetCorrectionUncertainty from files...";
+			if ((! settings.GetJetEnergyCorrectionUncertaintyParameters().empty()) &&
+				(settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0))
+			{
+				JetCorrectorParameters* jecUncertaintyParameters = nullptr;
+				if (!settings.GetJetEnergyCorrectionUncertaintySource().empty()) {
+					jecUncertaintyParameters = new JetCorrectorParameters(
 						settings.GetJetEnergyCorrectionUncertaintyParameters(),
 						settings.GetJetEnergyCorrectionUncertaintySource()
-				);
+					);
+				}
+				else {
+					jecUncertaintyParameters = new JetCorrectorParameters(settings.GetJetEnergyCorrectionUncertaintyParameters());
+				}
+				if ((!jecUncertaintyParameters->isValid()) || (jecUncertaintyParameters->size() == 0))
+					LOG(FATAL) << "Invalid definition " << settings.GetJetEnergyCorrectionUncertaintySource()
+						 << " in file " << settings.GetJetEnergyCorrectionUncertaintyParameters();
+				jetCorrectionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
+				LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintySource();
+				LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintyParameters();
 			}
-			else {
-				jecUncertaintyParameters = new JetCorrectorParameters(settings.GetJetEnergyCorrectionUncertaintyParameters());
-			}
-			if ((!jecUncertaintyParameters->isValid()) || (jecUncertaintyParameters->size() == 0))
-				LOG(FATAL) << "Invalid definition " << settings.GetJetEnergyCorrectionUncertaintySource()
-						   << " in file " << settings.GetJetEnergyCorrectionUncertaintyParameters();
-			jetCorrectionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
-			LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintySource();
-			LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintyParameters();
-		}
 
-				uncertaintyFile = settings.GetJetEnergyCorrectionSplitUncertaintyParameters();
-				individualUncertainties = settings.GetJetEnergyCorrectionSplitUncertaintyParameterNames();
+			uncertaintyFile = settings.GetJetEnergyCorrectionSplitUncertaintyParameters();
+			individualUncertainties = settings.GetJetEnergyCorrectionSplitUncertaintyParameterNames();
 
-				// make sure the necessary parameters are configured
-				assert(uncertaintyFile != "");
-				if (settings.GetUseGroupedJetEnergyCorrectionUncertainty()) assert(individualUncertainties.size() > 0);
+			// make sure the necessary parameters are configured
+			assert(uncertaintyFile != "");
+			if (settings.GetUseGroupedJetEnergyCorrectionUncertainty()) assert(individualUncertainties.size() > 0);
 
-				for (auto const& uncertainty : individualUncertainties)
-				{
-						// only do string comparison once per uncertainty
-						KappaEnumTypes::JetEnergyUncertaintyShiftName individualUncertainty = KappaEnumTypes::ToJetEnergyUncertaintyShiftName(uncertainty);
-						if (individualUncertainty == KappaEnumTypes::JetEnergyUncertaintyShiftName::NONE)
+			for (auto const& uncertainty : individualUncertainties)
+			{
+				// only do string comparison once per uncertainty
+				KappaEnumTypes::JetEnergyUncertaintyShiftName individualUncertainty = KappaEnumTypes::ToJetEnergyUncertaintyShiftName(uncertainty);
+				if (individualUncertainty == KappaEnumTypes::JetEnergyUncertaintyShiftName::NONE)
 								continue;
-						individualUncertaintyEnums.push_back(individualUncertainty);
+				individualUncertaintyEnums.push_back(individualUncertainty);
 
-						// create uncertainty map (only if shifts are to be applied)
-						if (settings.GetUseGroupedJetEnergyCorrectionUncertainty()
-								&& settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0
-								&& individualUncertainty != KappaEnumTypes::JetEnergyUncertaintyShiftName::Closure)
-						{
-								JetCorrectorParameters const * jetCorPar = new JetCorrectorParameters(uncertaintyFile, uncertainty);
-								JetCorParMap[individualUncertainty] = jetCorPar;
+				// create uncertainty map (only if shifts are to be applied)
+				if (settings.GetUseGroupedJetEnergyCorrectionUncertainty()
+					&& settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0
+					&& individualUncertainty != KappaEnumTypes::JetEnergyUncertaintyShiftName::Closure)
+				{
+					JetCorrectorParameters const * jetCorPar = new JetCorrectorParameters(uncertaintyFile, uncertainty);
+					JetCorParMap[individualUncertainty] = jetCorPar;
 
-								JetCorrectionUncertainty * jecUnc(new JetCorrectionUncertainty(*JetCorParMap[individualUncertainty]));
-								JetUncMap[individualUncertainty] = jecUnc;
-						}
+					JetCorrectionUncertainty * jecUnc(new JetCorrectionUncertainty(*JetCorParMap[individualUncertainty]));
+					JetUncMap[individualUncertainty] = jecUnc;
 				}
-				assert(settings.GetJetEnergyResolutionSource() != "");
-				assert(settings.GetJetEnergyResolutionSFSource() != "");
-				m_jetResolution.reset(new JME::JetResolution(settings.GetJetEnergyResolutionSource()));
-				m_jetResolutionScaleFactor.reset(new JME::JetResolutionScaleFactor(settings.GetJetEnergyResolutionSFSource()));
-				if(settings.GetJetEnergyResolutionUncertaintyShift()==0.0) JER_shift = Variation::NOMINAL;
-				else if(settings.GetJetEnergyResolutionUncertaintyShift()==1.0) JER_shift = Variation::UP;
-				else if(settings.GetJetEnergyResolutionUncertaintyShift()==-1.0) JER_shift = Variation::DOWN;
-				else LOG(FATAL) << "Invalid definition of JetEnergyResolutionUncertaintyShift: " << settings.GetJetEnergyResolutionUncertaintyShift();
-	}
-
-	void Produce(KappaEvent const& event, KappaProduct& product,
-						 KappaSettings const& settings) const override
-	{
-				LOG(DEBUG) << "\nStarting " << this->GetProducerId() <<  ". Consider pipeline: " << settings.GetRootFileFolder();
-		assert((event.*m_basicJetsMember));
-		assert(event.m_pileupDensity);
-		assert(event.m_vertexSummary);
-		// create a copy of all jets in the event (first temporarily for the JEC)
-		(product.*m_correctedJetsMember).clear();
-		std::vector<TJet> correctJetsForJecTools((event.*m_basicJetsMember)->size());
-		size_t jetIndex = 0;
-		for (typename std::vector<TJet>::const_iterator jet = (event.*m_basicJetsMember)->begin();
-			 jet != (event.*m_basicJetsMember)->end(); ++jet)
-		{
-			correctJetsForJecTools[jetIndex] = *jet;
-			++jetIndex;
+			}
+			assert(settings.GetJetEnergyResolutionSource() != "");
+			assert(settings.GetJetEnergyResolutionSFSource() != "");
+			m_jetResolution.reset(new JME::JetResolution(settings.GetJetEnergyResolutionSource()));
+			m_jetResolutionScaleFactor.reset(new JME::JetResolutionScaleFactor(settings.GetJetEnergyResolutionSFSource()));
+			if(settings.GetJetEnergyResolutionUncertaintyShift()==0.0) JER_shift = Variation::NOMINAL;
+			else if(settings.GetJetEnergyResolutionUncertaintyShift()==1.0) JER_shift = Variation::UP;
+			else if(settings.GetJetEnergyResolutionUncertaintyShift()==-1.0) JER_shift = Variation::DOWN;
+			else LOG(FATAL) << "Invalid definition of JetEnergyResolutionUncertaintyShift: " << settings.GetJetEnergyResolutionUncertaintyShift();
 		}
 
-				if (settings.GetUseGroupedJetEnergyCorrectionUncertainty() && settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
-				{
-						// run over all jets
-						for (typename std::vector<TJet>::iterator jet = correctJetsForJecTools.begin();
-								 jet != correctJetsForJecTools.end(); ++jet)
-						{
-								LOG(DEBUG) << "\tConsidering jet with p4 = " << jet->p4;
-								// shift corrected jets
-								double grouped_unc = 0.0;
-				if(individualUncertaintyEnums.size() == 1)
-				{
+		void Produce(KappaEvent const& event, KappaProduct& product,
+												 KappaSettings const& settings) const override
+		{
+			LOG(DEBUG) << "\nStarting " << this->GetProducerId() <<  ". Consider pipeline: " << settings.GetRootFileFolder();
+			assert((event.*m_basicJetsMember));
+			assert(event.m_pileupDensity);
+			assert(event.m_vertexSummary);
+			// create a copy of all jets in the event (first temporarily for the JEC)
+			(product.*m_correctedJetsMember).clear();
+			std::vector<TJet> correctJetsForJecTools((event.*m_basicJetsMember)->size());
+			size_t jetIndex = 0;
+			for (typename std::vector<TJet>::const_iterator jet = (event.*m_basicJetsMember)->begin();
+				 jet != (event.*m_basicJetsMember)->end(); ++jet)
+			{
+				correctJetsForJecTools[jetIndex] = *jet;
+				++jetIndex;
+			}
 
-										if (std::abs(jet->p4.Eta()) < 5.2 && jet->p4.Pt() > 9.)
-										{
-												auto const& uncertainty = individualUncertaintyEnums.at(0);
-												JetUncMap.at(uncertainty)->setJetEta(jet->p4.Eta());
-												JetUncMap.at(uncertainty)->setJetPt(jet->p4.Pt());
-												grouped_unc = JetUncMap.at(uncertainty)->getUncertainty(true);
-										}
-				}
-				else
+			if (settings.GetUseGroupedJetEnergyCorrectionUncertainty() && settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
+			{
+				// run over all jets
+				for (typename std::vector<TJet>::iterator jet = correctJetsForJecTools.begin();
+					 jet != correctJetsForJecTools.end(); ++jet)
 				{
-					for (auto const& uncertainty : individualUncertaintyEnums)
+					LOG(DEBUG) << "\tConsidering jet with p4 = " << jet->p4;
+					// shift corrected jets
+					double grouped_unc = 0.0;
+					if(individualUncertaintyEnums.size() == 1)
 					{
-						double unc = 0.0;
-
 						if (std::abs(jet->p4.Eta()) < 5.2 && jet->p4.Pt() > 9.)
 						{
+							auto const& uncertainty = individualUncertaintyEnums.at(0);
 							JetUncMap.at(uncertainty)->setJetEta(jet->p4.Eta());
 							JetUncMap.at(uncertainty)->setJetPt(jet->p4.Pt());
-							unc = JetUncMap.at(uncertainty)->getUncertainty(true);
-							grouped_unc += unc * unc;
+							grouped_unc = JetUncMap.at(uncertainty)->getUncertainty(true);
 						}
 					}
-					grouped_unc = sqrt(grouped_unc);
-				}
-								if (jet->p4.Pt() * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift())>15.0){ // requirement for type I corrections
-										product.m_MET_shift.p4 += jet->p4;
-										jet->p4 = jet->p4 * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift());
-										product.m_MET_shift.p4 -= jet->p4;
-								} else {
-										jet->p4 = jet->p4 * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift());
-								}
-								LOG(DEBUG) << "\tGrouped uncertainty applied: " << grouped_unc << " shifted p4: " << jet->p4;
+					else
+					{
+						for (auto const& uncertainty : individualUncertaintyEnums)
+						{
+							double unc = 0.0;
+
+							if (std::abs(jet->p4.Eta()) < 5.2 && jet->p4.Pt() > 9.)
+							{
+								JetUncMap.at(uncertainty)->setJetEta(jet->p4.Eta());
+								JetUncMap.at(uncertainty)->setJetPt(jet->p4.Pt());
+								unc = JetUncMap.at(uncertainty)->getUncertainty(true);
+								grouped_unc += unc * unc;
+							}
 						}
+						grouped_unc = sqrt(grouped_unc);
+					}
+					if (jet->p4.Pt() * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift())>15.0){ // requirement for type I corrections
+						product.m_MET_shift.p4 += jet->p4;
+						jet->p4 = jet->p4 * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift());
+						product.m_MET_shift.p4 -= jet->p4;
+					} else {
+						jet->p4 = jet->p4 * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift());
+					}
+					LOG(DEBUG) << "\tGrouped uncertainty applied: " << grouped_unc << " shifted p4: " << jet->p4;
 				}
-				else if (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
-				{
-		// apply jet energy corrections and uncertainty shift (if uncertainties are not to be splitted into individual contributions)
-		float shift = settings.GetJetEnergyCorrectionSplitUncertainty() ? 0.0 : settings.GetJetEnergyCorrectionUncertaintyShift();
-		correctJets(&correctJetsForJecTools, factorizedJetCorrector, jetCorrectionUncertainty,
-					event.m_pileupDensity->rho, event.m_vertexSummary->nVertices, -1,
-					shift);
-				}
-				// apply JER smearing
-				for (typename std::vector<TJet>::iterator jet = correctJetsForJecTools.begin();
-								 jet != correctJetsForJecTools.end(); ++jet)
-				{
-						randm.SetSeed(static_cast<int>((jet->p4.Eta() + 5) * 1000) * 1000 + static_cast<int>((jet->p4.Phi() + 4) * 1000) + 10000);
-						double jetResolution = m_jetResolution->getResolution({
-							{JME::Binning::JetPt, jet->p4.Pt()},
-							{JME::Binning::JetEta, jet->p4.Eta()},
-							{JME::Binning::Rho, event.m_pileupDensity->rho}
-						});
-						double jetResolutionScaleFactor = m_jetResolutionScaleFactor->getScaleFactor({
-							{JME::Binning::JetPt, jet->p4.Pt()},
-							{JME::Binning::JetEta, jet->p4.Eta()}
-						}, JER_shift);
-						double shift = randm.Gaus(0, jetResolution) * std::sqrt(std::max(jetResolutionScaleFactor * jetResolutionScaleFactor - 1, 0.0));
-						if (shift < -1.0) shift = -1.0;
-						if ((jet->p4*(1.0+shift)).Pt()>15.0) product.m_MET_shift.p4 -= jet->p4*shift; // requirement for type I corrections
-						jet->p4 *= 1.0 + shift;
-				}
-		// create the shared pointers to store in the product
-		(product.*m_correctedJetsMember).clear();
-		(product.*m_correctedJetsMember).resize(correctJetsForJecTools.size());
-		jetIndex = 0;
-		for (typename std::vector<TJet>::const_iterator jet = correctJetsForJecTools.begin();
-			 jet != correctJetsForJecTools.end(); ++jet)
-		{
-			(product.*m_correctedJetsMember)[jetIndex] = std::shared_ptr<TJet>(new TJet(*jet));
-			product.m_originalJets[(product.*m_correctedJetsMember)[jetIndex].get()] = &(*jet);
-			++jetIndex;
+			}
+			else if (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
+			{
+				// apply jet energy corrections and uncertainty shift (if uncertainties are not to be splitted into individual contributions)
+				float shift = settings.GetJetEnergyCorrectionSplitUncertainty() ? 0.0 : settings.GetJetEnergyCorrectionUncertaintyShift();
+				correctJets(&correctJetsForJecTools, factorizedJetCorrector, jetCorrectionUncertainty,
+							event.m_pileupDensity->rho, event.m_vertexSummary->nVertices, -1,
+							shift);
+			}
+			// apply JER smearing
+			for (typename std::vector<TJet>::iterator jet = correctJetsForJecTools.begin();
+											 jet != correctJetsForJecTools.end(); ++jet)
+			{
+				randm.SetSeed(static_cast<int>((jet->p4.Eta() + 5) * 1000) * 1000 + static_cast<int>((jet->p4.Phi() + 4) * 1000) + 10000);
+				double jetResolution = m_jetResolution->getResolution({
+						{JME::Binning::JetPt, jet->p4.Pt()},
+						{JME::Binning::JetEta, jet->p4.Eta()},
+						{JME::Binning::Rho, event.m_pileupDensity->rho}
+				});
+				double jetResolutionScaleFactor = m_jetResolutionScaleFactor->getScaleFactor({
+						{JME::Binning::JetPt, jet->p4.Pt()},
+						{JME::Binning::JetEta, jet->p4.Eta()}
+				}, JER_shift);
+				double shift = randm.Gaus(0, jetResolution) * std::sqrt(std::max(jetResolutionScaleFactor * jetResolutionScaleFactor - 1, 0.0));
+				if (shift < -1.0) shift = -1.0;
+				if ((jet->p4*(1.0+shift)).Pt()>15.0) product.m_MET_shift.p4 -= jet->p4*shift; // requirement for type I corrections
+				jet->p4 *= 1.0 + shift;
+			}
+			// create the shared pointers to store in the product
+			(product.*m_correctedJetsMember).clear();
+			(product.*m_correctedJetsMember).resize(correctJetsForJecTools.size());
+			jetIndex = 0;
+			for (typename std::vector<TJet>::const_iterator jet = correctJetsForJecTools.begin();
+				 jet != correctJetsForJecTools.end(); ++jet)
+			{
+				(product.*m_correctedJetsMember)[jetIndex] = std::shared_ptr<TJet>(new TJet(*jet));
+				product.m_originalJets[(product.*m_correctedJetsMember)[jetIndex].get()] = &(*jet);
+				++jetIndex;
+			}
+
+			// perform additional corrections on copied jets
+			for (typename std::vector<std::shared_ptr<TJet> >::iterator jet = (product.*m_correctedJetsMember).begin();
+				 jet != (product.*m_correctedJetsMember).end(); ++jet)
+			{
+				AdditionalCorrections(jet->get(), event, product, settings);
+				LOG(DEBUG) << "\tFinal jet p4: " << (*jet)->p4;
+			}
+
+			// sort vectors of corrected jets by pt
+			std::sort((product.*m_correctedJetsMember).begin(), (product.*m_correctedJetsMember).end(),
+				[](std::shared_ptr<TJet> jet1, std::shared_ptr<TJet> jet2) -> bool
+				{ return jet1->p4.Pt() > jet2->p4.Pt(); });
 		}
 
-		// perform additional corrections on copied jets
-		for (typename std::vector<std::shared_ptr<TJet> >::iterator jet = (product.*m_correctedJetsMember).begin();
-			 jet != (product.*m_correctedJetsMember).end(); ++jet)
+
+	protected:
+		// Can be overwritten for analysis-specific use cases
+		virtual void AdditionalCorrections(TJet* jet, KappaEvent const& event,
+			KappaProduct& product, KappaSettings const& settings) const
 		{
-			AdditionalCorrections(jet->get(), event, product, settings);
-						LOG(DEBUG) << "\tFinal jet p4: " << (*jet)->p4;
 		}
 
-		// sort vectors of corrected jets by pt
-		std::sort((product.*m_correctedJetsMember).begin(), (product.*m_correctedJetsMember).end(),
-				  [](std::shared_ptr<TJet> jet1, std::shared_ptr<TJet> jet2) -> bool
-				  { return jet1->p4.Pt() > jet2->p4.Pt(); });
-	}
 
+	private:
+		std::vector<TJet>* KappaEvent::*m_basicJetsMember;
+		std::vector<std::shared_ptr<TJet> > KappaProduct::*m_correctedJetsMember;
 
-protected:
-	// Can be overwritten for analysis-specific use cases
-	virtual void AdditionalCorrections(TJet* jet, KappaEvent const& event,
-									   KappaProduct& product, KappaSettings const& settings) const
-	{
-	}
+		std::string uncertaintyFile;
+		std::vector<std::string> individualUncertainties;
+		std::vector<KappaEnumTypes::JetEnergyUncertaintyShiftName> individualUncertaintyEnums;
 
+		std::map<KappaEnumTypes::JetEnergyUncertaintyShiftName, JetCorrectorParameters const*> JetCorParMap;
+		std::map<KappaEnumTypes::JetEnergyUncertaintyShiftName, JetCorrectionUncertainty *> JetUncMap;
 
-private:
-	std::vector<TJet>* KappaEvent::*m_basicJetsMember;
-	std::vector<std::shared_ptr<TJet> > KappaProduct::*m_correctedJetsMember;
-
-	std::string uncertaintyFile;
-	std::vector<std::string> individualUncertainties;
-	std::vector<KappaEnumTypes::JetEnergyUncertaintyShiftName> individualUncertaintyEnums;
-
-	std::map<KappaEnumTypes::JetEnergyUncertaintyShiftName, JetCorrectorParameters const*> JetCorParMap;
-	std::map<KappaEnumTypes::JetEnergyUncertaintyShiftName, JetCorrectionUncertainty *> JetUncMap;
-
-	FactorizedJetCorrector* factorizedJetCorrector = nullptr;
-	JetCorrectionUncertainty* jetCorrectionUncertainty = nullptr;
+		FactorizedJetCorrector* factorizedJetCorrector = nullptr;
+		JetCorrectionUncertainty* jetCorrectionUncertainty = nullptr;
 
 		mutable TRandom3 randm = TRandom3(0);
 		std::unique_ptr<JME::JetResolution> m_jetResolution;
@@ -289,32 +288,32 @@ private:
 
 
 /**
-   \brief Producer for Jet Energy Correction (JEC)
+	 \brief Producer for Jet Energy Correction (JEC)
 
-   Operates on the vector event.m_basicJets and product::m_correctedJets.
+	 Operates on the vector event.m_basicJets and product::m_correctedJets.
 */
 class JetCorrectionsProducer: public JetCorrectionsProducerBase<KBasicJet>
 {
-public:
-	JetCorrectionsProducer();
+	public:
+		JetCorrectionsProducer();
 
-	std::string GetProducerId() const override;
+		std::string GetProducerId() const override;
 };
 
 
 
 /**
-   \brief Producer for Jet Energy Correction (JEC)
+	 \brief Producer for Jet Energy Correction (JEC)
 
-   Operates on the vector event.m_tjets and product::m_correctedTaggedJets.
+	 Operates on the vector event.m_tjets and product::m_correctedTaggedJets.
 */
 class TaggedJetCorrectionsProducer: public JetCorrectionsProducerBase<KJet>
 {
-public:
+	public:
 
-	TaggedJetCorrectionsProducer();
+		TaggedJetCorrectionsProducer();
 
-	std::string GetProducerId() const override;
+		std::string GetProducerId() const override;
 };
 
 

--- a/KappaAnalysis/interface/Producers/JetCorrectionsProducer.h
+++ b/KappaAnalysis/interface/Producers/JetCorrectionsProducer.h
@@ -39,7 +39,7 @@
    https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyCorrections#JetEnCorFWLite
 
    TODO: the code can be moved to a .cc file, if there are no external users using the TJet templated
-         version
+		 version
 */
 
 
@@ -50,7 +50,7 @@ class JetCorrectionsProducerBase: public KappaProducerBase
 public:
 
 	JetCorrectionsProducerBase(std::vector<TJet>* KappaEvent::*jets,
-	                           std::vector<std::shared_ptr<TJet> > KappaProduct::*correctedJets) :
+							   std::vector<std::shared_ptr<TJet> > KappaProduct::*correctedJets) :
 		KappaProducerBase(),
 		m_basicJetsMember(jets),
 		m_correctedJetsMember(correctedJets)
@@ -70,7 +70,7 @@ public:
 		LOG(DEBUG) << "\tLoading JetCorrectorParameters from files...";
 		std::vector<JetCorrectorParameters> jecParameters;
 		for (std::vector<std::string>::const_iterator jecParametersFile = settings.GetJetEnergyCorrectionParameters().begin();
-		     jecParametersFile != settings.GetJetEnergyCorrectionParameters().end(); ++jecParametersFile)
+			 jecParametersFile != settings.GetJetEnergyCorrectionParameters().end(); ++jecParametersFile)
 		{
 			jecParameters.push_back(JetCorrectorParameters(*jecParametersFile));
 			LOG(DEBUG) << "\t\t" << *jecParametersFile;
@@ -83,7 +83,7 @@ public:
 		// initialise uncertainty calculation
 		LOG(DEBUG) << "\tLoading JetCorrectionUncertainty from files...";
 		if ((! settings.GetJetEnergyCorrectionUncertaintyParameters().empty()) &&
-		    (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0))
+			(settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0))
 		{
 			JetCorrectorParameters* jecUncertaintyParameters = nullptr;
 			if (!settings.GetJetEnergyCorrectionUncertaintySource().empty()) {
@@ -97,53 +97,53 @@ public:
 			}
 			if ((!jecUncertaintyParameters->isValid()) || (jecUncertaintyParameters->size() == 0))
 				LOG(FATAL) << "Invalid definition " << settings.GetJetEnergyCorrectionUncertaintySource()
-				           << " in file " << settings.GetJetEnergyCorrectionUncertaintyParameters();
+						   << " in file " << settings.GetJetEnergyCorrectionUncertaintyParameters();
 			jetCorrectionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
 			LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintySource();
 			LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintyParameters();
 		}
 
-                uncertaintyFile = settings.GetJetEnergyCorrectionSplitUncertaintyParameters();
-                individualUncertainties = settings.GetJetEnergyCorrectionSplitUncertaintyParameterNames();
+				uncertaintyFile = settings.GetJetEnergyCorrectionSplitUncertaintyParameters();
+				individualUncertainties = settings.GetJetEnergyCorrectionSplitUncertaintyParameterNames();
 
-                // make sure the necessary parameters are configured
-                assert(uncertaintyFile != "");
-                if (settings.GetUseGroupedJetEnergyCorrectionUncertainty()) assert(individualUncertainties.size() > 0);
+				// make sure the necessary parameters are configured
+				assert(uncertaintyFile != "");
+				if (settings.GetUseGroupedJetEnergyCorrectionUncertainty()) assert(individualUncertainties.size() > 0);
 
-                for (auto const& uncertainty : individualUncertainties)
-                {
-                        // only do string comparison once per uncertainty
-                        KappaEnumTypes::JetEnergyUncertaintyShiftName individualUncertainty = KappaEnumTypes::ToJetEnergyUncertaintyShiftName(uncertainty);
-                        if (individualUncertainty == KappaEnumTypes::JetEnergyUncertaintyShiftName::NONE)
-                                continue;
-                        individualUncertaintyEnums.push_back(individualUncertainty);
+				for (auto const& uncertainty : individualUncertainties)
+				{
+						// only do string comparison once per uncertainty
+						KappaEnumTypes::JetEnergyUncertaintyShiftName individualUncertainty = KappaEnumTypes::ToJetEnergyUncertaintyShiftName(uncertainty);
+						if (individualUncertainty == KappaEnumTypes::JetEnergyUncertaintyShiftName::NONE)
+								continue;
+						individualUncertaintyEnums.push_back(individualUncertainty);
 
-                        // create uncertainty map (only if shifts are to be applied)
-                        if (settings.GetUseGroupedJetEnergyCorrectionUncertainty()
-                                && settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0
-                                && individualUncertainty != KappaEnumTypes::JetEnergyUncertaintyShiftName::Closure)
-                        {
-                                JetCorrectorParameters const * jetCorPar = new JetCorrectorParameters(uncertaintyFile, uncertainty);
-                                JetCorParMap[individualUncertainty] = jetCorPar;
+						// create uncertainty map (only if shifts are to be applied)
+						if (settings.GetUseGroupedJetEnergyCorrectionUncertainty()
+								&& settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0
+								&& individualUncertainty != KappaEnumTypes::JetEnergyUncertaintyShiftName::Closure)
+						{
+								JetCorrectorParameters const * jetCorPar = new JetCorrectorParameters(uncertaintyFile, uncertainty);
+								JetCorParMap[individualUncertainty] = jetCorPar;
 
-                                JetCorrectionUncertainty * jecUnc(new JetCorrectionUncertainty(*JetCorParMap[individualUncertainty]));
-                                JetUncMap[individualUncertainty] = jecUnc;
-                        }
-                }
-                assert(settings.GetJetEnergyResolutionSource() != "");
-                assert(settings.GetJetEnergyResolutionSFSource() != "");
-                m_jetResolution.reset(new JME::JetResolution(settings.GetJetEnergyResolutionSource()));
-                m_jetResolutionScaleFactor.reset(new JME::JetResolutionScaleFactor(settings.GetJetEnergyResolutionSFSource()));
-                if(settings.GetJetEnergyResolutionUncertaintyShift()==0.0) JER_shift = Variation::NOMINAL;
-                else if(settings.GetJetEnergyResolutionUncertaintyShift()==1.0) JER_shift = Variation::UP;
-                else if(settings.GetJetEnergyResolutionUncertaintyShift()==-1.0) JER_shift = Variation::DOWN;
-                else LOG(FATAL) << "Invalid definition of JetEnergyResolutionUncertaintyShift: " << settings.GetJetEnergyResolutionUncertaintyShift();
+								JetCorrectionUncertainty * jecUnc(new JetCorrectionUncertainty(*JetCorParMap[individualUncertainty]));
+								JetUncMap[individualUncertainty] = jecUnc;
+						}
+				}
+				assert(settings.GetJetEnergyResolutionSource() != "");
+				assert(settings.GetJetEnergyResolutionSFSource() != "");
+				m_jetResolution.reset(new JME::JetResolution(settings.GetJetEnergyResolutionSource()));
+				m_jetResolutionScaleFactor.reset(new JME::JetResolutionScaleFactor(settings.GetJetEnergyResolutionSFSource()));
+				if(settings.GetJetEnergyResolutionUncertaintyShift()==0.0) JER_shift = Variation::NOMINAL;
+				else if(settings.GetJetEnergyResolutionUncertaintyShift()==1.0) JER_shift = Variation::UP;
+				else if(settings.GetJetEnergyResolutionUncertaintyShift()==-1.0) JER_shift = Variation::DOWN;
+				else LOG(FATAL) << "Invalid definition of JetEnergyResolutionUncertaintyShift: " << settings.GetJetEnergyResolutionUncertaintyShift();
 	}
 
 	void Produce(KappaEvent const& event, KappaProduct& product,
-	                     KappaSettings const& settings) const override
+						 KappaSettings const& settings) const override
 	{
-                LOG(DEBUG) << "\nStarting " << this->GetProducerId() <<  ". Consider pipeline: " << settings.GetRootFileFolder();
+				LOG(DEBUG) << "\nStarting " << this->GetProducerId() <<  ". Consider pipeline: " << settings.GetRootFileFolder();
 		assert((event.*m_basicJetsMember));
 		assert(event.m_pileupDensity);
 		assert(event.m_vertexSummary);
@@ -158,25 +158,25 @@ public:
 			++jetIndex;
 		}
 
-                if (settings.GetUseGroupedJetEnergyCorrectionUncertainty() && settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
-                {
-                        // run over all jets
-                        for (typename std::vector<TJet>::iterator jet = correctJetsForJecTools.begin();
-                                 jet != correctJetsForJecTools.end(); ++jet)
-                        {
-                                LOG(DEBUG) << "\tConsidering jet with p4 = " << jet->p4;
-                                // shift corrected jets
-                                double grouped_unc = 0.0;
+				if (settings.GetUseGroupedJetEnergyCorrectionUncertainty() && settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
+				{
+						// run over all jets
+						for (typename std::vector<TJet>::iterator jet = correctJetsForJecTools.begin();
+								 jet != correctJetsForJecTools.end(); ++jet)
+						{
+								LOG(DEBUG) << "\tConsidering jet with p4 = " << jet->p4;
+								// shift corrected jets
+								double grouped_unc = 0.0;
 				if(individualUncertaintyEnums.size() == 1)
 				{
 
-                                        if (std::abs(jet->p4.Eta()) < 5.2 && jet->p4.Pt() > 9.)
-                                        {
-                                                auto const& uncertainty = individualUncertaintyEnums.at(0);
-                                                JetUncMap.at(uncertainty)->setJetEta(jet->p4.Eta());
-                                                JetUncMap.at(uncertainty)->setJetPt(jet->p4.Pt());
-                                                grouped_unc = JetUncMap.at(uncertainty)->getUncertainty(true);
-                                        }
+										if (std::abs(jet->p4.Eta()) < 5.2 && jet->p4.Pt() > 9.)
+										{
+												auto const& uncertainty = individualUncertaintyEnums.at(0);
+												JetUncMap.at(uncertainty)->setJetEta(jet->p4.Eta());
+												JetUncMap.at(uncertainty)->setJetPt(jet->p4.Pt());
+												grouped_unc = JetUncMap.at(uncertainty)->getUncertainty(true);
+										}
 				}
 				else
 				{
@@ -194,43 +194,43 @@ public:
 					}
 					grouped_unc = sqrt(grouped_unc);
 				}
-                                if (jet->p4.Pt() * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift())>15.0){ // requirement for type I corrections
-                                        product.m_MET_shift.p4 += jet->p4;
-                                        jet->p4 = jet->p4 * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift());
-                                        product.m_MET_shift.p4 -= jet->p4;
-                                } else {
-                                        jet->p4 = jet->p4 * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift());
-                                }
-                                LOG(DEBUG) << "\tGrouped uncertainty applied: " << grouped_unc << " shifted p4: " << jet->p4;
-                        }
-                }
-                else if (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
-                {
+								if (jet->p4.Pt() * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift())>15.0){ // requirement for type I corrections
+										product.m_MET_shift.p4 += jet->p4;
+										jet->p4 = jet->p4 * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift());
+										product.m_MET_shift.p4 -= jet->p4;
+								} else {
+										jet->p4 = jet->p4 * (1 + grouped_unc * settings.GetJetEnergyCorrectionUncertaintyShift());
+								}
+								LOG(DEBUG) << "\tGrouped uncertainty applied: " << grouped_unc << " shifted p4: " << jet->p4;
+						}
+				}
+				else if (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
+				{
 		// apply jet energy corrections and uncertainty shift (if uncertainties are not to be splitted into individual contributions)
 		float shift = settings.GetJetEnergyCorrectionSplitUncertainty() ? 0.0 : settings.GetJetEnergyCorrectionUncertaintyShift();
 		correctJets(&correctJetsForJecTools, factorizedJetCorrector, jetCorrectionUncertainty,
-		            event.m_pileupDensity->rho, event.m_vertexSummary->nVertices, -1,
-		            shift);
-                }
-                // apply JER smearing
-                for (typename std::vector<TJet>::iterator jet = correctJetsForJecTools.begin();
-                                 jet != correctJetsForJecTools.end(); ++jet)
-                {
-                        randm.SetSeed(static_cast<int>((jet->p4.Eta() + 5) * 1000) * 1000 + static_cast<int>((jet->p4.Phi() + 4) * 1000) + 10000);
-                        double jetResolution = m_jetResolution->getResolution({
-                            {JME::Binning::JetPt, jet->p4.Pt()},
-                            {JME::Binning::JetEta, jet->p4.Eta()},
-                            {JME::Binning::Rho, event.m_pileupDensity->rho}
-                        });
-                        double jetResolutionScaleFactor = m_jetResolutionScaleFactor->getScaleFactor({
-                            {JME::Binning::JetPt, jet->p4.Pt()},
-                            {JME::Binning::JetEta, jet->p4.Eta()}
-                        }, JER_shift);
-                        double shift = randm.Gaus(0, jetResolution) * std::sqrt(std::max(jetResolutionScaleFactor * jetResolutionScaleFactor - 1, 0.0));
-                        if (shift < -1.0) shift = -1.0;
-                        if ((jet->p4*(1.0+shift)).Pt()>15.0) product.m_MET_shift.p4 -= jet->p4*shift; // requirement for type I corrections
-                        jet->p4 *= 1.0 + shift;
-                }
+					event.m_pileupDensity->rho, event.m_vertexSummary->nVertices, -1,
+					shift);
+				}
+				// apply JER smearing
+				for (typename std::vector<TJet>::iterator jet = correctJetsForJecTools.begin();
+								 jet != correctJetsForJecTools.end(); ++jet)
+				{
+						randm.SetSeed(static_cast<int>((jet->p4.Eta() + 5) * 1000) * 1000 + static_cast<int>((jet->p4.Phi() + 4) * 1000) + 10000);
+						double jetResolution = m_jetResolution->getResolution({
+							{JME::Binning::JetPt, jet->p4.Pt()},
+							{JME::Binning::JetEta, jet->p4.Eta()},
+							{JME::Binning::Rho, event.m_pileupDensity->rho}
+						});
+						double jetResolutionScaleFactor = m_jetResolutionScaleFactor->getScaleFactor({
+							{JME::Binning::JetPt, jet->p4.Pt()},
+							{JME::Binning::JetEta, jet->p4.Eta()}
+						}, JER_shift);
+						double shift = randm.Gaus(0, jetResolution) * std::sqrt(std::max(jetResolutionScaleFactor * jetResolutionScaleFactor - 1, 0.0));
+						if (shift < -1.0) shift = -1.0;
+						if ((jet->p4*(1.0+shift)).Pt()>15.0) product.m_MET_shift.p4 -= jet->p4*shift; // requirement for type I corrections
+						jet->p4 *= 1.0 + shift;
+				}
 		// create the shared pointers to store in the product
 		(product.*m_correctedJetsMember).clear();
 		(product.*m_correctedJetsMember).resize(correctJetsForJecTools.size());
@@ -248,20 +248,20 @@ public:
 			 jet != (product.*m_correctedJetsMember).end(); ++jet)
 		{
 			AdditionalCorrections(jet->get(), event, product, settings);
-                        LOG(DEBUG) << "\tFinal jet p4: " << (*jet)->p4;
+						LOG(DEBUG) << "\tFinal jet p4: " << (*jet)->p4;
 		}
 
 		// sort vectors of corrected jets by pt
 		std::sort((product.*m_correctedJetsMember).begin(), (product.*m_correctedJetsMember).end(),
-		          [](std::shared_ptr<TJet> jet1, std::shared_ptr<TJet> jet2) -> bool
-		          { return jet1->p4.Pt() > jet2->p4.Pt(); });
+				  [](std::shared_ptr<TJet> jet1, std::shared_ptr<TJet> jet2) -> bool
+				  { return jet1->p4.Pt() > jet2->p4.Pt(); });
 	}
 
 
 protected:
 	// Can be overwritten for analysis-specific use cases
 	virtual void AdditionalCorrections(TJet* jet, KappaEvent const& event,
-	                                   KappaProduct& product, KappaSettings const& settings) const
+									   KappaProduct& product, KappaSettings const& settings) const
 	{
 	}
 
@@ -280,10 +280,10 @@ private:
 	FactorizedJetCorrector* factorizedJetCorrector = nullptr;
 	JetCorrectionUncertainty* jetCorrectionUncertainty = nullptr;
 
-        mutable TRandom3 randm = TRandom3(0);
-        std::unique_ptr<JME::JetResolution> m_jetResolution;
-        std::unique_ptr<JME::JetResolutionScaleFactor> m_jetResolutionScaleFactor;
-        Variation JER_shift;
+		mutable TRandom3 randm = TRandom3(0);
+		std::unique_ptr<JME::JetResolution> m_jetResolution;
+		std::unique_ptr<JME::JetResolutionScaleFactor> m_jetResolutionScaleFactor;
+		Variation JER_shift;
 };
 
 

--- a/KappaAnalysis/interface/Producers/TmvaClassificationMultiReaderBase.h
+++ b/KappaAnalysis/interface/Producers/TmvaClassificationMultiReaderBase.h
@@ -24,14 +24,14 @@ public:
 	typedef typename TTypes::event_type event_type;
 	typedef typename TTypes::product_type product_type;
 	typedef typename TTypes::setting_type setting_type;
-	typedef std::function<float(event_type const&, product_type const&)> float_extractor_lambda;
-	
+	typedef std::function<float(event_type const&, product_type const&, setting_type const&)> float_extractor_lambda;
+
 	static double GetMvaOutput(std::string const& methodName, std::vector<double> const& mvaOutputs)
 	{
 		auto methodNameIndex = std::find(mvaOutputs.begin(), mvaOutputs.end(), methodName);
 		return (methodNameIndex == mvaOutputs.end() ? DefaultValues::UndefinedDouble : mvaOutputs[methodNameIndex - mvaOutputs.begin()]);
 	}
-	
+
 	TmvaClassificationMultiReaderBase(std::vector<std::string>& (setting_type::*GetTmvaInputQuantities)(void) const,
 								 std::vector<std::string>& (setting_type::*GetTmvaMethods)(void) const,
 								 std::vector<std::string>& (setting_type::*GetTmvaWeights)(void) const,
@@ -43,7 +43,7 @@ public:
 		m_mvaOutputsMember(mvaOutputs)
 	{
 	}
-	
+
 	void Init(setting_type const& settings) override
 	{
 		ProducerBase<TTypes>::Init(settings);
@@ -123,7 +123,7 @@ public:
 			mvaMethodIndex += 1;
 		}
 	}
-	
+
 	void Produce(event_type const& event, product_type& product,
 						 setting_type const& settings) const override
 	{
@@ -136,7 +136,7 @@ public:
 			for(typename std::vector<float_extractor_lambda>::const_iterator inputExtractor = Extractor_vec.begin();
 				inputExtractor != Extractor_vec.end(); ++inputExtractor)
 			{
-				*(tmvaInputs[input_index][inputQuantityIndex]) = (*inputExtractor)(event, product);
+				*(tmvaInputs[input_index][inputQuantityIndex]) = (*inputExtractor)(event, product, settings);
 				++inputQuantityIndex;
 			}
 		}
@@ -152,7 +152,7 @@ public:
 			mvaMethodIndex += 1;
 		}
 	}
-	
+
 private:
 	std::vector<std::string>& (setting_type::*GetTmvaInputQuantities)(void) const;
 	std::vector<std::string>& (setting_type::*GetTmvaMethods)(void) const;

--- a/KappaAnalysis/interface/Producers/TmvaClassificationReaderBase.h
+++ b/KappaAnalysis/interface/Producers/TmvaClassificationReaderBase.h
@@ -23,15 +23,15 @@ public:
 	typedef typename TTypes::event_type event_type;
 	typedef typename TTypes::product_type product_type;
 	typedef typename TTypes::setting_type setting_type;
-	
-	typedef std::function<float(event_type const&, product_type const&)> float_extractor_lambda;
-	
+
+	typedef std::function<float(event_type const&, product_type const&, setting_type const&)> float_extractor_lambda;
+
 	static double GetMvaOutput(std::string const& methodName, std::vector<double> const& mvaOutputs)
 	{
 		auto methodNameIndex = std::find(mvaOutputs.begin(), mvaOutputs.end(), methodName);
 		return (methodNameIndex == mvaOutputs.end() ? DefaultValues::UndefinedDouble : mvaOutputs[methodNameIndex - mvaOutputs.begin()]);
 	}
-	
+
 	TmvaClassificationReaderBase(std::vector<std::string>& (setting_type::*GetTmvaInputQuantities)(void) const,
 								 std::vector<std::string>& (setting_type::*GetTmvaMethods)(void) const,
 								 std::vector<std::string>& (setting_type::*GetTmvaWeights)(void) const,
@@ -47,7 +47,7 @@ public:
 	void Init(setting_type const& settings) override
 	{
 		ProducerBase<TTypes>::Init(settings);
-		
+
 		// construct extractors vector
 		m_inputExtractors.clear();
 		for (std::vector<std::string>::const_iterator quantity = (settings.*GetTmvaInputQuantities)().begin();
@@ -58,7 +58,7 @@ public:
 			transform(splitted.begin(), splitted.end(), splitted.begin(),
 					  [](std::string s) { return boost::algorithm::trim_copy(s); });
 			std::string lambdaQuantity = splitted.front();
-			
+
 			if (LambdaNtupleConsumer<TTypes>::GetFloatQuantities().count(lambdaQuantity) > 0)
 			{
 				m_inputExtractors.push_back(SafeMap::Get(LambdaNtupleConsumer<TTypes>::GetFloatQuantities(), lambdaQuantity));
@@ -72,14 +72,14 @@ public:
 				LOG(FATAL) << "The TMVA interface currently only supports float-type and int-type input variables!";
 			}
 		}
-		
+
 		// register TMVA input variables
 		for (std::vector<std::string>::const_iterator quantity = (settings.*GetTmvaInputQuantities)().begin();
 			 quantity != (settings.*GetTmvaInputQuantities)().end(); ++quantity)
 		{
 			tmvaReader.AddVariable(*quantity, static_cast<float*>(nullptr));
 		}
-		
+
 		// loading TMVA weight files
 		assert((settings.*GetTmvaMethods)().size() == (settings.*GetTmvaWeights)().size());
 		LOG(INFO) << "\tLoading TMVA weight files...";
@@ -101,10 +101,10 @@ public:
 		for(typename std::vector<float_extractor_lambda>::const_iterator inputExtractor = m_inputExtractors.begin();
 			inputExtractor != m_inputExtractors.end(); ++inputExtractor)
 		{
-			tmvaInputs[inputQuantityIndex] = (*inputExtractor)(event, product);
+			tmvaInputs[inputQuantityIndex] = (*inputExtractor)(event, product, settings);
 			++inputQuantityIndex;
 		}
-		
+
 		// retrieve MVA outputs
 		(product.*m_mvaOutputsMember) = std::vector<double>((settings.*GetTmvaMethods)().size());
 		for (size_t mvaMethodIndex = 0; mvaMethodIndex < (settings.*GetTmvaMethods)().size(); ++mvaMethodIndex)
@@ -120,7 +120,7 @@ private:
 	std::vector<std::string>& (setting_type::*GetTmvaMethods)(void) const;
 	std::vector<std::string>& (setting_type::*GetTmvaWeights)(void) const;
 	std::vector<double> product_type::*m_mvaOutputsMember;
-	
+
 	std::vector<float_extractor_lambda> m_inputExtractors;
 	mutable TMVA::Reader tmvaReader;
 
@@ -129,7 +129,7 @@ private:
 
 /**
    \brief Producer for general MVA discriminators
-   
+
    Required config tags:
    - TmvaInputQuantities
    - TmvaMethods
@@ -140,7 +140,7 @@ class GeneralTmvaClassificationReader: public TmvaClassificationReaderBase<Kappa
 public:
 
 	std::string GetProducerId() const override;
-	
+
 	GeneralTmvaClassificationReader();
-	
+
 };

--- a/KappaAnalysis/interface/Producers/ValidJetsProducer.h
+++ b/KappaAnalysis/interface/Producers/ValidJetsProducer.h
@@ -83,11 +83,11 @@ public:
 			return KappaProduct::GetNJetsAbovePtThreshold(product.m_validJets, 80.0);
 		});
 		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets20Eta2p4",[this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
-            std::vector<std::shared_ptr<TValidJet>> filteredJets;
+            std::vector<std::unique_ptr<TValidJet>> filteredJets;
 			for (typename std::vector<TValidJet*>::const_iterator jet = (product.m_validJets).begin();
 				 jet != (product.m_validJets).end(); ++jet)
 			{
-				if ((*jet)->p4.Eta() < 2.4) filteredJets.push_back(new TValidJet(*(*jet)));
+				if ((*jet)->p4.Eta() < 2.4) filteredJets.push_back(std::make_unique<TValidJet>(*(*jet)));
 			}
 			return KappaProduct::GetNJetsAbovePtThreshold(filteredJets, 20.0);
 		});

--- a/KappaAnalysis/interface/Producers/ValidJetsProducer.h
+++ b/KappaAnalysis/interface/Producers/ValidJetsProducer.h
@@ -92,99 +92,99 @@ public:
 			return KappaProduct::GetNJetsAbovePtThreshold(filteredJets, 20.0);
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingJetLV", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 				return product.m_validJets.size() >= 1 ? (product.m_validJets.at(0)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(0)->p4 : DefaultValues::UndefinedRMFLV) : DefaultValues::UndefinedRMFLV;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetPt", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 1 ? (product.m_validJets.at(0)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(0)->p4.Pt() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetEta", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 1 ? (product.m_validJets.at(0)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(0)->p4.Eta() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetPhi", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 1 ? (product.m_validJets.at(0)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(0)->p4.Phi() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetMass", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 1 ? (product.m_validJets.at(0)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(0)->p4.mass() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("trailingJetLV", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("trailingJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 2 ? (product.m_validJets.at(1)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(1)->p4 : DefaultValues::UndefinedRMFLV) : DefaultValues::UndefinedRMFLV;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetPt", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 2 ? (product.m_validJets.at(1)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(1)->p4.Pt() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetEta", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 2 ? (product.m_validJets.at(1)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(1)->p4.Eta() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetPhi", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 2 ? (product.m_validJets.at(1)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(1)->p4.Phi() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetMass", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 2 ? (product.m_validJets.at(1)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(1)->p4.mass() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("thirdJetLV", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("thirdJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 3 ? (product.m_validJets.at(2)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(2)->p4 : DefaultValues::UndefinedRMFLV) : DefaultValues::UndefinedRMFLV;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetPt", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 3 ? (product.m_validJets.at(2)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(2)->p4.Pt() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetEta", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 3 ? (product.m_validJets.at(2)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(2)->p4.Eta() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetPhi", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 3 ? (product.m_validJets.at(2)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(2)->p4.Phi() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetMass", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 3 ? (product.m_validJets.at(2)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(2)->p4.mass() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("fourthJetLV", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("fourthJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 4 ? (product.m_validJets.at(3)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(3)->p4 : DefaultValues::UndefinedRMFLV) : DefaultValues::UndefinedRMFLV;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetPt", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 4 ? (product.m_validJets.at(3)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(3)->p4.Pt() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetEta", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 4 ? (product.m_validJets.at(3)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(3)->p4.Eta() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetPhi", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 4 ? (product.m_validJets.at(3)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(3)->p4.Phi() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetMass", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 4 ? (product.m_validJets.at(3)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(3)->p4.mass() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("fifthJetLV", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("fifthJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 5 ? (product.m_validJets.at(4)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(4)->p4 : DefaultValues::UndefinedRMFLV) : DefaultValues::UndefinedRMFLV;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetPt", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 5 ? (product.m_validJets.at(4)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(4)->p4.Pt() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetEta", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 5 ? (product.m_validJets.at(4)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(4)->p4.Eta() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetPhi", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 5 ? (product.m_validJets.at(4)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(4)->p4.Phi() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetMass", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 5 ? (product.m_validJets.at(4)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(4)->p4.mass() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("sixthJetLV", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("sixthJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 6 ? (product.m_validJets.at(5)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(5)->p4 : DefaultValues::UndefinedRMFLV) : DefaultValues::UndefinedRMFLV;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetPt", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 6 ? (product.m_validJets.at(5)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(5)->p4.Pt() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetEta", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 6 ? (product.m_validJets.at(5)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(5)->p4.Eta() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetPhi", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 6 ? (product.m_validJets.at(5)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(5)->p4.Phi() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetMass", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 6 ? (product.m_validJets.at(5)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(5)->p4.mass() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
 	}

--- a/KappaAnalysis/interface/Producers/ValidJetsProducer.h
+++ b/KappaAnalysis/interface/Producers/ValidJetsProducer.h
@@ -67,22 +67,22 @@ public:
 			LOG(WARNING) << "This jet ID version is not valid for 73X samples.";
 
 		// add possible quantities for the lambda ntuples consumers
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size();
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets20",[this](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets20",[this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return KappaProduct::GetNJetsAbovePtThreshold(product.m_validJets, 20.0);
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets30",[this](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets30",[this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return KappaProduct::GetNJetsAbovePtThreshold(product.m_validJets, 30.0);
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets50",[this](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets50",[this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return KappaProduct::GetNJetsAbovePtThreshold(product.m_validJets, 50.0);
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets80",[this](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets80",[this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return KappaProduct::GetNJetsAbovePtThreshold(product.m_validJets, 80.0);
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets20Eta2p4",[this](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets20Eta2p4",[this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
             std::vector<TValidJet*> filteredJets;
 			for (typename std::vector<TValidJet*>::const_iterator jet = (product.m_validJets).begin();
 				 jet != (product.m_validJets).end(); ++jet)
@@ -92,99 +92,99 @@ public:
 			return KappaProduct::GetNJetsAbovePtThreshold(filteredJets, 20.0);
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingJetLV", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingJetLV", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 				return product.m_validJets.size() >= 1 ? (product.m_validJets.at(0)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(0)->p4 : DefaultValues::UndefinedRMFLV) : DefaultValues::UndefinedRMFLV;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetPt", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetPt", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 1 ? (product.m_validJets.at(0)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(0)->p4.Pt() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetEta", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetEta", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 1 ? (product.m_validJets.at(0)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(0)->p4.Eta() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetPhi", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetPhi", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 1 ? (product.m_validJets.at(0)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(0)->p4.Phi() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetMass", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetMass", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 1 ? (product.m_validJets.at(0)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(0)->p4.mass() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("trailingJetLV", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("trailingJetLV", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 2 ? (product.m_validJets.at(1)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(1)->p4 : DefaultValues::UndefinedRMFLV) : DefaultValues::UndefinedRMFLV;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetPt", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetPt", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 2 ? (product.m_validJets.at(1)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(1)->p4.Pt() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetEta", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetEta", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 2 ? (product.m_validJets.at(1)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(1)->p4.Eta() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetPhi", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetPhi", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 2 ? (product.m_validJets.at(1)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(1)->p4.Phi() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetMass", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetMass", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 2 ? (product.m_validJets.at(1)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(1)->p4.mass() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("thirdJetLV", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("thirdJetLV", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 3 ? (product.m_validJets.at(2)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(2)->p4 : DefaultValues::UndefinedRMFLV) : DefaultValues::UndefinedRMFLV;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetPt", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetPt", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 3 ? (product.m_validJets.at(2)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(2)->p4.Pt() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetEta", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetEta", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 3 ? (product.m_validJets.at(2)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(2)->p4.Eta() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetPhi", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetPhi", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 3 ? (product.m_validJets.at(2)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(2)->p4.Phi() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetMass", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetMass", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 3 ? (product.m_validJets.at(2)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(2)->p4.mass() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("fourthJetLV", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("fourthJetLV", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 4 ? (product.m_validJets.at(3)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(3)->p4 : DefaultValues::UndefinedRMFLV) : DefaultValues::UndefinedRMFLV;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetPt", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetPt", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 4 ? (product.m_validJets.at(3)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(3)->p4.Pt() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetEta", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetEta", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 4 ? (product.m_validJets.at(3)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(3)->p4.Eta() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetPhi", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetPhi", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 4 ? (product.m_validJets.at(3)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(3)->p4.Phi() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetMass", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetMass", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 4 ? (product.m_validJets.at(3)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(3)->p4.mass() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("fifthJetLV", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("fifthJetLV", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 5 ? (product.m_validJets.at(4)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(4)->p4 : DefaultValues::UndefinedRMFLV) : DefaultValues::UndefinedRMFLV;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetPt", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetPt", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 5 ? (product.m_validJets.at(4)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(4)->p4.Pt() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetEta", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetEta", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 5 ? (product.m_validJets.at(4)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(4)->p4.Eta() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetPhi", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetPhi", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 5 ? (product.m_validJets.at(4)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(4)->p4.Phi() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetMass", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthJetMass", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 5 ? (product.m_validJets.at(4)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(4)->p4.mass() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("sixthJetLV", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("sixthJetLV", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 6 ? (product.m_validJets.at(5)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(5)->p4 : DefaultValues::UndefinedRMFLV) : DefaultValues::UndefinedRMFLV;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetPt", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetPt", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 6 ? (product.m_validJets.at(5)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(5)->p4.Pt() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetEta", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetEta", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 6 ? (product.m_validJets.at(5)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(5)->p4.Eta() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetPhi", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetPhi", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 6 ? (product.m_validJets.at(5)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(5)->p4.Phi() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetMass", [settings](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthJetMass", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validJets.size() >= 6 ? (product.m_validJets.at(5)->p4.Pt() >= settings.GetJetOfflineLowerPtCut() ? product.m_validJets.at(5)->p4.mass() : DefaultValues::UndefinedFloat) : DefaultValues::UndefinedFloat;
 		});
 	}
@@ -199,7 +199,7 @@ public:
 		std::vector<TJet*> jets;
 		if ((validJetsInput == KappaEnumTypes::ValidJetsInput::AUTO && ((product.*m_correctedJetsMember).size() > 0)) || (validJetsInput == KappaEnumTypes::ValidJetsInput::CORRECTED))
 		{
-                        LOG(DEBUG) << "Choosing corrected jets as input source"; 
+                        LOG(DEBUG) << "Choosing corrected jets as input source";
 			jets.resize((product.*m_correctedJetsMember).size());
 			size_t jetIndex = 0;
 			for (typename std::vector<std::shared_ptr<TJet> >::iterator jet = (product.*m_correctedJetsMember).begin();
@@ -211,7 +211,7 @@ public:
 		}
 		else
 		{
-                        LOG(DEBUG) << "Choosing original jets as input source"; 
+                        LOG(DEBUG) << "Choosing original jets as input source";
 			jets.resize((event.*m_basicJetsMember)->size());
 			size_t jetIndex = 0;
 			for (typename std::vector<TJet>::iterator jet = (event.*m_basicJetsMember)->begin(); jet != (event.*m_basicJetsMember)->end(); ++jet)
@@ -221,14 +221,14 @@ public:
 			}
 		}
 
-                LOG(DEBUG) << "Initial size of jets: " << jets.size(); 
+                LOG(DEBUG) << "Initial size of jets: " << jets.size();
 		for (typename std::vector<TJet*>::iterator jet = jets.begin(); jet != jets.end(); ++jet)
 		{
 			bool validJet = true;
-                        LOG(DEBUG) << "Checking jet with p4 " << (*jet)->p4; 
+                        LOG(DEBUG) << "Checking jet with p4 " << (*jet)->p4;
 
 			validJet = validJet && passesJetID(*jet, jetIDVersion, jetID);
-                        LOG(DEBUG) << "\tPassing ID's? " << validJet; 
+                        LOG(DEBUG) << "\tPassing ID's? " << validJet;
 
 			// remove leptons from list of jets via simple DeltaR isolation
 			for (std::vector<KLepton*>::const_iterator lepton = product.m_validLeptons.begin();
@@ -369,7 +369,7 @@ public:
 				&& (jet->nCharged > 0)
 				&& (jet->electronFraction < 0.99f);
 				LOG(DEBUG) << "2016 loose ID - eta < 2.4 id = " << validJet;
-			}			
+			}
 			if (std::abs(jet->p4.eta()) > 2.4f && std::abs(jet->p4.eta()) <= 2.7f)
 			{
 				validJet = (jet->neutralHadronFraction < 0.99f)
@@ -402,7 +402,7 @@ public:
 				&& (jet->chargedHadronFraction > 0.0)
 				&& (jet->nCharged > 0);
 				LOG(DEBUG) << "2017 tight ID - eta < 2.4 id = " << validJet;
-			}			
+			}
 			if (std::abs(jet->p4.eta()) > 2.4f && std::abs(jet->p4.eta()) <= 2.7f)
 			{
 				validJet = (jet->neutralHadronFraction < 0.90f)

--- a/KappaAnalysis/interface/Producers/ValidJetsProducer.h
+++ b/KappaAnalysis/interface/Producers/ValidJetsProducer.h
@@ -83,7 +83,7 @@ public:
 			return KappaProduct::GetNJetsAbovePtThreshold(product.m_validJets, 80.0);
 		});
 		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets20Eta2p4",[this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
-            std::vector<TValidJet*> filteredJets;
+            std::vector<std::shared_ptr<TValidJet>> filteredJets;
 			for (typename std::vector<TValidJet*>::const_iterator jet = (product.m_validJets).begin();
 				 jet != (product.m_validJets).end(); ++jet)
 			{

--- a/KappaAnalysis/interface/Producers/ValidJetsProducer.h
+++ b/KappaAnalysis/interface/Producers/ValidJetsProducer.h
@@ -83,13 +83,8 @@ public:
 			return KappaProduct::GetNJetsAbovePtThreshold(product.m_validJets, 80.0);
 		});
 		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nJets20Eta2p4",[this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
-            std::vector<std::unique_ptr<TValidJet>> filteredJets;
-			for (typename std::vector<TValidJet*>::const_iterator jet = (product.m_validJets).begin();
-				 jet != (product.m_validJets).end(); ++jet)
-			{
-				if ((*jet)->p4.Eta() < 2.4) filteredJets.push_back(std::make_unique<TValidJet>(*(*jet)));
-			}
-			return KappaProduct::GetNJetsAbovePtThreshold(filteredJets, 20.0);
+			return std::count_if(product.m_validJets.begin(), product.m_validJets.end(),
+				[](TValidJet* const jet) {return jet->p4.Eta() < 2.4 && jet->p4.Pt() > 20;});
 		});
 
 		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {

--- a/KappaAnalysis/interface/Producers/ValidMuonsProducer.h
+++ b/KappaAnalysis/interface/Producers/ValidMuonsProducer.h
@@ -151,22 +151,22 @@ public:
 		muonIso = ToMuonIso(boost::algorithm::to_lower_copy(boost::algorithm::trim_copy((settings.*GetMuonIso)())));
 
 		// add possible quantities for the lambda ntuples consumers
-		LambdaNtupleConsumer<TTypes>::AddIntQuantity("nMuons", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddIntQuantity("nMuons", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return product.m_validMuons.size();
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("leadingMuonPt", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("leadingMuonPt", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return product.m_validMuons.size() >= 1 ? product.m_validMuons[0]->p4.Pt() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("leadingMuonEta", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("leadingMuonEta", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return product.m_validMuons.size() >= 1 ? product.m_validMuons[0]->p4.Eta() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("trailingMuonPt", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("trailingMuonPt", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return product.m_validMuons.size() >= 2 ? product.m_validMuons[1]->p4.Pt() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("trailingMuonEta", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("trailingMuonEta", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			return product.m_validMuons.size() >= 2 ? product.m_validMuons[1]->p4.Eta() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("leadingMuMinusPt", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("leadingMuMinusPt", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			for (unsigned int i = 0; i < product.m_validMuons.size(); ++i)
 			{
 				if (product.m_validMuons[i]->charge() < 0)
@@ -176,7 +176,7 @@ public:
 			}
 			return DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("leadingMuPlusPt", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("leadingMuPlusPt", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			for (unsigned int i = 0; i < product.m_validMuons.size(); ++i)
 			{
 				if (product.m_validMuons[i]->charge() > 0)
@@ -186,7 +186,7 @@ public:
 			}
 			return DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("leadingMuMinusEta", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("leadingMuMinusEta", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			for (unsigned int i = 0; i < product.m_validMuons.size(); ++i)
 			{
 				if (product.m_validMuons[i]->charge() < 0)
@@ -196,7 +196,7 @@ public:
 			}
 			return DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("leadingMuPlusEta", [](event_type const& event, product_type const& product) {
+		LambdaNtupleConsumer<TTypes>::AddFloatQuantity("leadingMuPlusEta", [](event_type const& event, product_type const& product, setting_type const& settings) {
 			for (unsigned int i = 0; i < product.m_validMuons.size(); ++i)
 			{
 				if (product.m_validMuons[i]->charge() > 0)
@@ -211,15 +211,15 @@ public:
 	void Produce(event_type const& event, product_type& product,
 	                     setting_type const& settings) const override
 	{
-		LOG(DEBUG) << this->GetProducerId() << " -----START-----"; 
-		LOG(DEBUG) << "Processing run:lumi:event " << event.m_eventInfo->nRun << ":" << event.m_eventInfo->nLumi << ":" << event.m_eventInfo->nEvent; 
+		LOG(DEBUG) << this->GetProducerId() << " -----START-----";
+		LOG(DEBUG) << "Processing run:lumi:event " << event.m_eventInfo->nRun << ":" << event.m_eventInfo->nLumi << ":" << event.m_eventInfo->nEvent;
 		assert(event.m_muons);
 
 		// select input source
 		std::vector<KMuon*> muons;
 		if ((validMuonsInput == ValidMuonsInput::AUTO && (product.m_correctedMuons.size() > 0)) || (validMuonsInput == ValidMuonsInput::CORRECTED))
 		{
-                        LOG(DEBUG) << "Choosing corrected muons as input source"; 
+                        LOG(DEBUG) << "Choosing corrected muons as input source";
 			muons.resize(product.m_correctedMuons.size());
 			size_t muonIndex = 0;
 			for (std::vector<std::shared_ptr<KMuon> >::iterator muon = product.m_correctedMuons.begin();
@@ -231,7 +231,7 @@ public:
 		}
 		else
 		{
-                        LOG(DEBUG) << "Choosing original muons as input source"; 
+                        LOG(DEBUG) << "Choosing original muons as input source";
 			muons.resize(event.m_muons->size());
 			size_t muonIndex = 0;
 			for (KMuons::iterator muon = event.m_muons->begin(); muon != event.m_muons->end(); ++muon)
@@ -241,12 +241,12 @@ public:
 			}
 		}
 
-                LOG(DEBUG) << "Initial size of muons: " << muons.size(); 
+                LOG(DEBUG) << "Initial size of muons: " << muons.size();
 		// Apply muon isolation and MuonID
 		for (std::vector<KMuon*>::iterator muon = muons.begin(); muon != muons.end(); ++muon)
 		{
 			bool validMuon = true;
-                        LOG(DEBUG) << "Checking muon with p4 " << (*muon)->p4; 
+                        LOG(DEBUG) << "Checking muon with p4 " << (*muon)->p4;
 
 			// Muon ID according to Muon POG definitions
 			if (muonID == MuonID::TIGHT) {
@@ -295,7 +295,7 @@ public:
 			{
 				LOG(FATAL) << "Muon ID of type " << Utility::ToUnderlyingValue(muonID) << " not yet implemented!";
 			}
-                        LOG(DEBUG) << "\tPassing ID's? " << validMuon; 
+                        LOG(DEBUG) << "\tPassing ID's? " << validMuon;
 
 			// Muon Isolation according to Muon POG definitions (independent of year)
 			// https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMuonId#Muon_Isolation
@@ -330,15 +330,15 @@ public:
 			}
 			else if (muonIsoType != MuonIsoType::USER && muonIsoType != MuonIsoType::NONE)
 				LOG(FATAL) << "Muon isolation type of type " << Utility::ToUnderlyingValue(muonIsoType) << " not yet implemented!";
-                        LOG(DEBUG) << "\tPassing isolation? " << validMuon; 
+                        LOG(DEBUG) << "\tPassing isolation? " << validMuon;
 
 			// kinematic cuts
 			validMuon = validMuon && this->PassKinematicCuts(*muon, event, product);
-                        LOG(DEBUG) << "\tPassing kinematic cuts? " << validMuon; 
+                        LOG(DEBUG) << "\tPassing kinematic cuts? " << validMuon;
 
 			// check possible analysis-specific criteria
 			validMuon = validMuon && AdditionalCriteria(*muon, event, product, settings);
-                        LOG(DEBUG) << "\tPassing additional analysis criteria? " << validMuon; 
+                        LOG(DEBUG) << "\tPassing additional analysis criteria? " << validMuon;
 
 			if (validMuon)
 			{
@@ -349,7 +349,7 @@ public:
 				(product.*m_invalidMuonsMember).push_back(*muon);
 			}
 		}
-                LOG(DEBUG) << this->GetProducerId() << " -----END-----"; 
+                LOG(DEBUG) << this->GetProducerId() << " -----END-----";
 	}
 
 	static bool IsEmbeddingMuon(const KMuon* muon, event_type const& event, product_type& product)

--- a/KappaAnalysis/interface/Producers/ValidTausProducer.h
+++ b/KappaAnalysis/interface/Producers/ValidTausProducer.h
@@ -86,120 +86,120 @@ public:
                 veto2prongs = settings.GetTauVeto2ProngDMs();
 
 		// add possible quantities for the lambda ntuples consumers
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nTaus", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nTaus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size();
 		} );
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingTauLV", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingTauLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->p4 : DefaultValues::UndefinedRMFLV;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauPt", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->p4.Pt() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauEta", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->p4.Eta() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauPhi", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->p4.Phi() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauMass", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->p4.mass() : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("leadingTauDecayMode", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("leadingTauDecayMode", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->decayMode : DefaultValues::UndefinedInt;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauCharge", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauCharge", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->charge() : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingTauSumChargedHadronsLV", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingTauSumChargedHadronsLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->sumChargedHadronCandidates() : DefaultValues::UndefinedRMFLV;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumChargedHadronsPt", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumChargedHadronsPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->sumChargedHadronCandidates().Pt() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumChargedHadronsEta", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumChargedHadronsEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->sumChargedHadronCandidates().Eta() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumChargedHadronsPhi", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumChargedHadronsPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->sumChargedHadronCandidates().Phi() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumChargedHadronsMass", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumChargedHadronsMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->sumChargedHadronCandidates().mass() : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingTauSumNeutralHadronsLV", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingTauSumNeutralHadronsLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->piZeroMomentum() : DefaultValues::UndefinedRMFLV;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumNeutralHadronsPt", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumNeutralHadronsPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->piZeroMomentum().Pt() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumNeutralHadronsEta", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumNeutralHadronsEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->piZeroMomentum().Eta() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumNeutralHadronsPhi", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumNeutralHadronsPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->piZeroMomentum().Phi() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumNeutralHadronsMass", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingTauSumNeutralHadronsMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 1 ? product.m_validTaus[0]->piZeroMomentum().mass() : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("trailingTauLV", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("trailingTauLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->p4 : DefaultValues::UndefinedRMFLV;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauPt", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->p4.Pt() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauEta", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->p4.Eta() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauPhi", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->p4.Phi() : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("trailingTauDecayMode", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("trailingTauDecayMode", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->decayMode : DefaultValues::UndefinedInt;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauCharge", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauCharge", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->charge() : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("trailingTauSumChargedHadronsLV", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("trailingTauSumChargedHadronsLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->sumChargedHadronCandidates() : DefaultValues::UndefinedRMFLV;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumChargedHadronsPt", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumChargedHadronsPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->sumChargedHadronCandidates().Pt() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumChargedHadronsEta", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumChargedHadronsEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->sumChargedHadronCandidates().Eta() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumChargedHadronsPhi", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumChargedHadronsPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->sumChargedHadronCandidates().Phi() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumChargedHadronsMass", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumChargedHadronsMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->sumChargedHadronCandidates().mass() : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("trailingTauSumNeutralHadronsLV", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("trailingTauSumNeutralHadronsLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->piZeroMomentum() : DefaultValues::UndefinedRMFLV;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumNeutralHadronsPt", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumNeutralHadronsPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->piZeroMomentum().Pt() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumNeutralHadronsEta", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumNeutralHadronsEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->piZeroMomentum().Eta() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumNeutralHadronsPhi", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumNeutralHadronsPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->piZeroMomentum().Phi() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumNeutralHadronsMass", [](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingTauSumNeutralHadronsMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			return product.m_validTaus.size() >= 2 ? product.m_validTaus[1]->piZeroMomentum().mass() : DefaultValues::UndefinedFloat;
 		});
 	}

--- a/KappaAnalysis/interface/Producers/ZProducer.h
+++ b/KappaAnalysis/interface/Producers/ZProducer.h
@@ -43,49 +43,49 @@ class ZProducerBase : public KappaProducerBase
 	{
 		KappaProducerBase::Init(settings);
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("ZMass", [](KappaEvent const & event, KappaProduct const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("ZMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 		{
 			return product.m_z.p4.M();
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingLeptonFromZPt", [](KappaEvent const & event, KappaProduct const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingLeptonFromZPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 		{
 			return product.m_zValid ? product.m_zLeptons.first->p4.Pt() : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingLeptonFromZEta", [](KappaEvent const & event, KappaProduct const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingLeptonFromZEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 		{
 			return product.m_zValid ? product.m_zLeptons.first->p4.Eta() : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingLeptonFromZPhi", [](KappaEvent const & event, KappaProduct const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingLeptonFromZPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 		{
 			return product.m_zValid ? product.m_zLeptons.first->p4.Phi() : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingLeptonFromZPt", [](KappaEvent const & event, KappaProduct const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingLeptonFromZPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 		{
 			return product.m_zValid ? product.m_zLeptons.second->p4.Pt() : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingLeptonFromZEta", [](KappaEvent const & event, KappaProduct const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingLeptonFromZEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 		{
 			return product.m_zValid ? product.m_zLeptons.second->p4.Eta() : DefaultValues::UndefinedFloat;
 		});
 
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingLeptonFromZPhi", [](KappaEvent const & event, KappaProduct const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingLeptonFromZPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 		{
 			return product.m_zValid ? product.m_zLeptons.second->p4.Phi() : DefaultValues::UndefinedFloat;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thetaZLepMinus", [](KappaEvent const & event, KappaProduct const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thetaZLepMinus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 		{
 			return product.m_theta_Z_LepMinus;
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("validZ", [](KappaEvent const & event, KappaProduct const & product)
+		LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("validZ", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 		{
 			return product.m_zValid;
 		});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nZCandidates", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nZCandidates", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 		{
 			return product.m_found_zs;
 		});

--- a/KappaAnalysis/interface/Utility/ValidPhysicsObjectTools.h
+++ b/KappaAnalysis/interface/Utility/ValidPhysicsObjectTools.h
@@ -40,6 +40,14 @@ public:
 		                                                               upperAbsEtaCutsByHltName);
 	}
 
+	virtual ~ValidPhysicsObjectTools() {
+		lowerPtCutsByIndex.clear();
+		lowerPtCutsByHltName.clear();
+		upperAbsEtaCutsByIndex.clear();
+		upperAbsEtaCutsByHltName.clear();
+
+		// m_validPhysicsObjectsMember
+	}
 
 protected:
 

--- a/KappaAnalysis/src/Filters/MaxObjectsCountFilters.cc
+++ b/KappaAnalysis/src/Filters/MaxObjectsCountFilters.cc
@@ -13,7 +13,7 @@
 		FilterBase<KappaTypes>::Init(settings);
 
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_validElectrons.size();
 				},
 				CutRange::UpperThresholdCut(double(settings.GetMaxNElectrons()))
@@ -33,7 +33,7 @@
 		FilterBase<KappaTypes>::Init(settings);
 
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_validMuons.size();
 				},
 				CutRange::UpperThresholdCut(double(settings.GetMaxNMuons()))
@@ -53,7 +53,7 @@
 		FilterBase<KappaTypes>::Init(settings);
 
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_validTaus.size();
 				},
 				CutRange::UpperThresholdCut(double(settings.GetMaxNTaus()))
@@ -73,7 +73,7 @@
 		FilterBase<KappaTypes>::Init(settings);
 
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_validJets.size();
 				},
 				CutRange::UpperThresholdCut(double(settings.GetMaxNJets()))
@@ -90,7 +90,7 @@
 
 	void MaxBTaggedJetsCountFilter::Init(KappaSettings const& settings) {
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_bTaggedJets.size();
 				},
 				CutRange::UpperThresholdCut(double(settings.GetMaxNBTaggedJets()))
@@ -108,7 +108,7 @@
 
 	void MaxNonBTaggedJetsCountFilter::Init(KappaSettings const& settings) {
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_nonBTaggedJets.size();
 				},
 				CutRange::UpperThresholdCut(double(settings.GetMaxNNonBTaggedJets()))

--- a/KappaAnalysis/src/Filters/MinObjectsCountFilters.cc
+++ b/KappaAnalysis/src/Filters/MinObjectsCountFilters.cc
@@ -13,7 +13,7 @@
 		FilterBase<KappaTypes>::Init(settings);
 
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_validElectrons.size();
 				},
 				CutRange::LowerThresholdCut(double(settings.GetMinNElectrons()))
@@ -33,7 +33,7 @@
 		FilterBase<KappaTypes>::Init(settings);
 
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_validMuons.size();
 				},
 				CutRange::LowerThresholdCut(double(settings.GetMinNMuons()))
@@ -53,7 +53,7 @@
 		FilterBase<KappaTypes>::Init(settings);
 
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_validTaus.size();
 				},
 				CutRange::LowerThresholdCut(double(settings.GetMinNTaus()))
@@ -73,7 +73,7 @@
 		FilterBase<KappaTypes>::Init(settings);
 
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_validJets.size();
 				},
 				CutRange::LowerThresholdCut(double(settings.GetMinNJets()))
@@ -90,7 +90,7 @@
 
 	void MinBTaggedJetsCountFilter::Init(KappaSettings const& settings) {
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_bTaggedJets.size();
 				},
 				CutRange::LowerThresholdCut(double(settings.GetMinNBTaggedJets()))
@@ -107,7 +107,7 @@
 
 	void MinNonBTaggedJetsCountFilter::Init(KappaSettings const& settings) {
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_nonBTaggedJets.size();
 				},
 				CutRange::LowerThresholdCut(double(settings.GetMinNNonBTaggedJets()))

--- a/KappaAnalysis/src/Filters/ObjectsCountFilters.cc
+++ b/KappaAnalysis/src/Filters/ObjectsCountFilters.cc
@@ -12,7 +12,7 @@
 		FilterBase<KappaTypes>::Init(settings);
 
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_validElectrons.size();
 				},
 				CutRange::EqualsCut(double(settings.GetNElectrons()))
@@ -32,7 +32,7 @@
 		FilterBase<KappaTypes>::Init(settings);
 
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_validMuons.size();
 				},
 				CutRange::EqualsCut(double(settings.GetNMuons()))
@@ -52,7 +52,7 @@
 		FilterBase<KappaTypes>::Init(settings);
 
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_validTaus.size();
 				},
 				CutRange::EqualsCut(double(settings.GetNTaus()))
@@ -72,7 +72,7 @@
 		FilterBase<KappaTypes>::Init(settings);
 
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_validJets.size();
 				},
 				CutRange::EqualsCut(double(settings.GetNJets()))
@@ -89,7 +89,7 @@
 
 	void BTaggedJetsCountFilter::Init(KappaSettings const& settings) {
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_bTaggedJets.size();
 				},
 				CutRange::EqualsCut(double(settings.GetNBTaggedJets()))
@@ -106,7 +106,7 @@
 
 	void NonBTaggedJetsCountFilter::Init(KappaSettings const& settings) {
 		this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-				[](KappaEvent const& event, KappaProduct const& product) {
+				[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 					return product.m_nonBTaggedJets.size();
 				},
 				CutRange::EqualsCut(double(settings.GetNNonBTaggedJets()))

--- a/KappaAnalysis/src/Filters/ValidObjectsFilters.cc
+++ b/KappaAnalysis/src/Filters/ValidObjectsFilters.cc
@@ -9,7 +9,7 @@ std::string ValidElectronsFilter::GetFilterId() const {
 void ValidElectronsFilter::Init(KappaSettings const& settings) {
 	CutRangeFilterBase::Init(settings);
 	this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-			[](KappaEvent const& event, KappaProduct const& product) {
+			[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 				return product.m_validElectrons.size();
 			},
 			CutRange::LowerThresholdCut(1.0)
@@ -23,7 +23,7 @@ std::string ValidMuonsFilter::GetFilterId() const {
 void ValidMuonsFilter::Init(KappaSettings const& settings) {
 	CutRangeFilterBase::Init(settings);
 	this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-			[](KappaEvent const& event, KappaProduct const& product) {
+			[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 				return product.m_validMuons.size();
 			},
 			CutRange::LowerThresholdCut(1.0)
@@ -37,7 +37,7 @@ std::string ValidTausFilter::GetFilterId() const {
 void ValidTausFilter::Init(KappaSettings const& settings) {
 	CutRangeFilterBase::Init(settings);
 	this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-			[](KappaEvent const& event, KappaProduct const& product) {
+			[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 				return product.m_validTaus.size();
 			},
 			CutRange::LowerThresholdCut(1.0)
@@ -52,7 +52,7 @@ std::string ValidJetsFilter::GetFilterId() const {
 void ValidJetsFilter::Init(KappaSettings const& settings) {
 	CutRangeFilterBase::Init(settings);
 	this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-			[](KappaEvent const& event, KappaProduct const& product) {
+			[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 				return product.m_validJets.size();
 			},
 			CutRange::LowerThresholdCut(1.0)
@@ -67,7 +67,7 @@ std::string ValidBTaggedJetsFilter::GetFilterId() const {
 void ValidBTaggedJetsFilter::Init(KappaSettings const& settings) {
 	CutRangeFilterBase::Init(settings);
 	this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-			[](KappaEvent const& event, KappaProduct const& product) {
+			[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 				return product.m_bTaggedJets.size();
 			},
 			CutRange::LowerThresholdCut(1.0)
@@ -82,7 +82,7 @@ std::string GenElectronsFilter::GetFilterId() const {
 void GenElectronsFilter::Init(KappaSettings const& settings) {
 	CutRangeFilterBase::Init(settings);
 	this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-			[](KappaEvent const& event, KappaProduct const& product) {
+			[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 				return product.m_genElectrons.size();
 			},
 			CutRange::LowerThresholdCut(1.0)
@@ -97,7 +97,7 @@ std::string GenMuonsFilter::GetFilterId() const {
 void GenMuonsFilter::Init(KappaSettings const& settings) {
 	CutRangeFilterBase::Init(settings);
 	this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-			[](KappaEvent const& event, KappaProduct const& product) {
+			[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 				return product.m_genMuons.size();
 			},
 			CutRange::LowerThresholdCut(1.0)
@@ -112,7 +112,7 @@ std::string GenTausFilter::GetFilterId() const {
 void GenTausFilter::Init(KappaSettings const& settings) {
 	CutRangeFilterBase::Init(settings);
 	this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-			[](KappaEvent const& event, KappaProduct const& product) {
+			[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 				return product.m_genTaus.size();
 			},
 			CutRange::LowerThresholdCut(1.0)
@@ -127,7 +127,7 @@ std::string GenTauJetsFilter::GetFilterId() const {
 void GenTauJetsFilter::Init(KappaSettings const& settings) {
 	CutRangeFilterBase::Init(settings);
 	this->m_cuts.push_back(std::pair<double_extractor_lambda, CutRange>(
-			[](KappaEvent const& event, KappaProduct const& product) {
+			[](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 				return product.m_genTauJets.size();
 			},
 			CutRange::LowerThresholdCut(1.0)

--- a/KappaAnalysis/src/Producers/GenBosonProducers.cc
+++ b/KappaAnalysis/src/Producers/GenBosonProducers.cc
@@ -14,128 +14,128 @@ void GenBosonFromGenParticlesProducer::Init(KappaSettings const& settings)
 	ProducerBase<KappaTypes>::Init(settings);
 	if (!settings.GetMatchNMSSMBosons()) {
 	// add possible quantities for the lambda ntuples consumers
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonParticleFound", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonParticleFound", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonParticle != nullptr);
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("genBosonLV", [](KappaEvent const & event, KappaProduct const & product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("genBosonLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV;
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPt", [](KappaEvent const & event, KappaProduct const & product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV.Pt();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonEta", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV.Eta();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPhi", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV.Phi();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonMass", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV.M();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonLVFound", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonLVFound", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLVFound;
 	});
 	}
 	else {
 	// add possible quantities for the lambda ntuples consumers
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonParticleFound_h1", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonParticleFound_h1", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonParticle_h1 != nullptr);
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("genBosonLV_h1", [](KappaEvent const & event, KappaProduct const & product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("genBosonLV_h1", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h1;
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPt_h1", [](KappaEvent const & event, KappaProduct const & product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPt_h1", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h1.Pt();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonEta_h1", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonEta_h1", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h1.Eta();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPhi_h1", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPhi_h1", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h1.Phi();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonMass_h1", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonMass_h1", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h1.M();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonLVFound_h1", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonLVFound_h1", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLVFound_h1;
 	});
 	// add possible quantities for the lambda ntuples consumers
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonParticleFound_h2", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonParticleFound_h2", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonParticle_h2 != nullptr);
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("genBosonLV_h2", [](KappaEvent const & event, KappaProduct const & product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("genBosonLV_h2", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h2;
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPt_h2", [](KappaEvent const & event, KappaProduct const & product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPt_h2", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h2.Pt();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonEta_h2", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonEta_h2", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h2.Eta();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPhi_h2", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPhi_h2", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h2.Phi();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonMass_h2", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonMass_h2", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h2.M();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonLVFound_h2", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonLVFound_h2", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLVFound_h2;
 	});
 	// add possible quantities for the lambda ntuples consumers
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonParticleFound_h3", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonParticleFound_h3", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonParticle_h3 != nullptr);
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("genBosonLV_h3", [](KappaEvent const & event, KappaProduct const & product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("genBosonLV_h3", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h3;
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPt_h3", [](KappaEvent const & event, KappaProduct const & product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPt_h3", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h3.Pt();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonEta_h3", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonEta_h3", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h3.Eta();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPhi_h3", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonPhi_h3", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h3.Phi();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonMass_h3", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("genBosonMass_h3", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLV_h3.M();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonLVFound_h3", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("genBosonLVFound_h3", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_genBosonLVFound_h3;
 	});
@@ -159,7 +159,7 @@ void GenBosonFromGenParticlesProducer::FindGenBoson(KappaEvent const& event, Kap
 		product.m_genBosonParticle = nullptr;
 		product.m_genBosonLV = RMFLV();
 		product.m_genBosonLVFound = false;
-		
+
 		for (unsigned int genParticleIndex = startIndex; genParticleIndex < event.m_genParticles->size(); ++genParticleIndex)
 		{
 			KGenParticle* genParticle = &(event.m_genParticles->at(genParticleIndex));
@@ -228,7 +228,7 @@ void GenBosonProductionProducer::Produce(KappaEvent const& event, KappaProduct& 
                                          KappaSettings const& settings) const
 {
 	assert(product.m_genBosonParticle != nullptr);
-	
+
 	// search for boson index
 	unsigned int bosonIndex = 0;
 	for (KGenParticles::const_iterator genParticle = event.m_genParticles->begin();
@@ -240,7 +240,7 @@ void GenBosonProductionProducer::Produce(KappaEvent const& event, KappaProduct& 
 		}
 		++bosonIndex;
 	}
-	
+
 	product.m_genParticlesProducingBoson = FindMothersWithDifferentPdgId(event.m_genParticles, bosonIndex, product.m_genBosonParticle->pdgId);
 }
 
@@ -250,7 +250,7 @@ std::vector<KGenParticle*> GenBosonProductionProducer::FindMothersWithDifferentP
 		int currentPdgId) const
 {
 	std::vector<KGenParticle*> mothers;
-	
+
 	unsigned int index = 0;
 	for (KGenParticles::iterator genParticle = genParticles->begin();
 		 genParticle != genParticles->end(); ++genParticle)
@@ -269,7 +269,7 @@ std::vector<KGenParticle*> GenBosonProductionProducer::FindMothersWithDifferentP
 		}
 		++index;
 	}
-	
+
 	return mothers;
 }
 
@@ -287,8 +287,8 @@ void GenBosonDiLeptonDecayModeProducer::Init(KappaSettings const& settings)
 	{
 		std::string lepQuantityNameBase = "genBosonLep" + std::to_string(leptonIndex+1);
 		std::string tauQuantityNameBase = "genBosonTau" + std::to_string(leptonIndex+1);
-		
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity(lepQuantityNameBase+"LV", [leptonIndex](event_type const& event, product_type const& product)
+
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity(lepQuantityNameBase+"LV", [leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			if (product.m_genLeptonsFromBosonDecay.size() > leptonIndex)
 			{
@@ -299,7 +299,7 @@ void GenBosonDiLeptonDecayModeProducer::Init(KappaSettings const& settings)
 				return DefaultValues::UndefinedRMFLV;
 			}
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity(tauQuantityNameBase+"LV", [leptonIndex](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity(tauQuantityNameBase+"LV", [leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			if (product.m_genLeptonsFromBosonDecay.size() > leptonIndex)
 			{
@@ -310,8 +310,8 @@ void GenBosonDiLeptonDecayModeProducer::Init(KappaSettings const& settings)
 				return DefaultValues::UndefinedRMFLV;
 			}
 		});
-		
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity(tauQuantityNameBase+"VisibleLV", [leptonIndex](event_type const& event, product_type const& product)
+
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity(tauQuantityNameBase+"VisibleLV", [leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			if ((product.m_genLeptonsFromBosonDecay.size() > leptonIndex) &&
 			    (std::abs(product.m_genLeptonsFromBosonDecay.at(leptonIndex)->pdgId) == DefaultValues::pdgIdTau))
@@ -324,7 +324,7 @@ void GenBosonDiLeptonDecayModeProducer::Init(KappaSettings const& settings)
 				return DefaultValues::UndefinedRMFLV;
 			}
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(tauQuantityNameBase+"DecayMode", [leptonIndex](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(tauQuantityNameBase+"DecayMode", [leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			if ((product.m_genLeptonsFromBosonDecay.size() > leptonIndex) &&
 			    (std::abs(product.m_genLeptonsFromBosonDecay.at(leptonIndex)->pdgId) == DefaultValues::pdgIdTau))
@@ -337,7 +337,7 @@ void GenBosonDiLeptonDecayModeProducer::Init(KappaSettings const& settings)
 				return DefaultValues::UndefinedInt;
 			}
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(tauQuantityNameBase+"NProngs", [leptonIndex](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(tauQuantityNameBase+"NProngs", [leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			if ((product.m_genLeptonsFromBosonDecay.size() > leptonIndex) &&
 			    (std::abs(product.m_genLeptonsFromBosonDecay.at(leptonIndex)->pdgId) == DefaultValues::pdgIdTau))
@@ -350,7 +350,7 @@ void GenBosonDiLeptonDecayModeProducer::Init(KappaSettings const& settings)
 				return DefaultValues::UndefinedInt;
 			}
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(tauQuantityNameBase+"NPi0s", [leptonIndex](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(tauQuantityNameBase+"NPi0s", [leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			if ((product.m_genLeptonsFromBosonDecay.size() > leptonIndex) &&
 			    (std::abs(product.m_genLeptonsFromBosonDecay.at(leptonIndex)->pdgId) == DefaultValues::pdgIdTau))
@@ -376,7 +376,7 @@ void GenBosonDiLeptonDecayModeProducer::FindGenDiLeptons(KappaEvent const& event
                                                          KappaSettings const& settings) const
 {
 	product.m_genLeptonsFromBosonDecay.clear();
-	
+
 	// If no boson has been found in the event, try to reconstruct it from the first two decay
 	// products available in the list of gen. particles
 	// https://hypernews.cern.ch/HyperNews/CMS/get/generators/2802/1.html
@@ -384,7 +384,7 @@ void GenBosonDiLeptonDecayModeProducer::FindGenDiLeptons(KappaEvent const& event
 	{
 		size_t iDaughter = 0;
 		RMFLV genBosonLV;
-		
+
 		for (KGenParticles::iterator genParticle = event.m_genParticles->begin();
 		     genParticle != event.m_genParticles->end() && (iDaughter < 2); ++genParticle)
 		{
@@ -398,7 +398,7 @@ void GenBosonDiLeptonDecayModeProducer::FindGenDiLeptons(KappaEvent const& event
 				++iDaughter;
 			}
 		}
-		
+
 		product.m_genBosonLV = genBosonLV;
 		product.m_genBosonLVFound = (iDaughter == 2);
 	}
@@ -427,7 +427,7 @@ void GenBosonDiLeptonDecayModeProducer::FindGenDiLeptons(KappaEvent const& event
 		{
 			rerun = true;
 		}
-		
+
 		if (rerun)
 		{
 			// search for boson index
@@ -441,10 +441,10 @@ void GenBosonDiLeptonDecayModeProducer::FindGenDiLeptons(KappaEvent const& event
 				}
 				++bosonIndex;
 			}
-			
+
 			// search for next boson
 			FindGenBoson(event, product, settings, bosonIndex+1);
-			
+
 			// restart search for leptons with next boson
 			FindGenDiLeptons(event, product, settings);
 		}

--- a/KappaAnalysis/src/Producers/GenDiLeptonDecayModeProducer.cc
+++ b/KappaAnalysis/src/Producers/GenDiLeptonDecayModeProducer.cc
@@ -16,55 +16,55 @@ void GenDiLeptonDecayModeProducer::Init(KappaSettings const& settings)
 	ProducerBase<KappaTypes>::Init(settings);
 
 	// add possible quantities for the lambda ntuples consumers
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZEE", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZEE", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genDiLeptonDecayMode == KappaEnumTypes::DiLeptonDecayMode::EE);
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZMM", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZMM", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genDiLeptonDecayMode == KappaEnumTypes::DiLeptonDecayMode::MM);
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZTT", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZTT", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genDiLeptonDecayMode == KappaEnumTypes::DiLeptonDecayMode::TT);
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZLL", [](KappaEvent const& event, KappaProduct const& product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZLL", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return ((product.m_genDiLeptonDecayMode == KappaEnumTypes::DiLeptonDecayMode::MM) || (product.m_genDiLeptonDecayMode == KappaEnumTypes::DiLeptonDecayMode::EE));
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("genDiLeptonDecayMode", [](KappaEvent const& event, KappaProduct const& product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("genDiLeptonDecayMode", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return Utility::ToUnderlyingValue(product.m_genDiLeptonDecayMode);
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZtt", [](KappaEvent const& event, KappaProduct const& product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZtt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genTauTauDecayMode == KappaEnumTypes::TauTauDecayMode::TT);
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZmt", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZmt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genTauTauDecayMode == KappaEnumTypes::TauTauDecayMode::MT);
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZet", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZet", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genTauTauDecayMode == KappaEnumTypes::TauTauDecayMode::ET);
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZee", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZee", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genTauTauDecayMode == KappaEnumTypes::TauTauDecayMode::EE);
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZmm", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZmm", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genTauTauDecayMode == KappaEnumTypes::TauTauDecayMode::MM);
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZem", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isZem", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genTauTauDecayMode == KappaEnumTypes::TauTauDecayMode::EM);
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("genTauTauDecayMode", [](KappaEvent const& event, KappaProduct const& product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("genTauTauDecayMode", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return Utility::ToUnderlyingValue(product.m_genTauTauDecayMode);
 	});
@@ -85,7 +85,7 @@ void GenDiLeptonDecayModeProducer::Produce(KappaEvent const& event, KappaProduct
 		nDecayProductsPerType[pdgId] = SafeMap::GetWithDefault(nDecayProductsPerType, pdgId, 0) + 1;
 		++iDaughter;
 	}
-	
+
 	if (SafeMap::GetWithDefault(nDecayProductsPerType, DefaultValues::pdgIdElectron, 0) >= 2)
 	{
 		product.m_genDiLeptonDecayMode = KappaEnumTypes::DiLeptonDecayMode::EE;
@@ -97,7 +97,7 @@ void GenDiLeptonDecayModeProducer::Produce(KappaEvent const& event, KappaProduct
 	else if (SafeMap::GetWithDefault(nDecayProductsPerType, DefaultValues::pdgIdTau, 0) >= 2)
 	{
 		product.m_genDiLeptonDecayMode = KappaEnumTypes::DiLeptonDecayMode::TT;
-		
+
 		// check tautau decay modes
 		size_t nElectronicDecays = 0;
 		size_t nMuonicDecays = 0;
@@ -124,7 +124,7 @@ void GenDiLeptonDecayModeProducer::Produce(KappaEvent const& event, KappaProduct
 			}
 			++iDaughter;
 		}
-		
+
 		if (nElectronicDecays == 0)
 		{
 			if ((nMuonicDecays == 0) && (nHadronicDecays == 2))

--- a/KappaAnalysis/src/Producers/GenMuonFSRProducer.cc
+++ b/KappaAnalysis/src/Producers/GenMuonFSRProducer.cc
@@ -9,12 +9,12 @@ std::string GenMuonFSRProducer::GetProducerId() const{
 void GenMuonFSRProducer::Init(KappaSettings const& settings)
 {
 	KappaProducerBase::Init(settings);
-	
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingMuonFSR", [](event_type const& event, product_type const& product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingMuonFSR", [](event_type const& event, product_type const& product, setting_type const& settings)
 	{
 		return product.m_sumMuonFSRPt[0];
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingMuonFSR", [](event_type const& event, product_type const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingMuonFSR", [](event_type const& event, product_type const& product, setting_type const& settings)
 	{
 		return product.m_sumMuonFSRPt[1];
 	});

--- a/KappaAnalysis/src/Producers/GenTauDecayProducer.cc
+++ b/KappaAnalysis/src/Producers/GenTauDecayProducer.cc
@@ -12,422 +12,422 @@ void GenTauDecayProducer::Init(KappaSettings const& settings)
 	KappaProducerBase::Init(settings);
 
 	// add possible quantities for the lambda ntuples consumers
-	
+
 	///*
 	// Boson daughters
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBosonDaughterSize", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBosonDaughterSize", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters.size() : DefaultValues::UndefinedInt;
 	});
 
 	// first daughter
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterPt", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_genParticle->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterPz", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterPz", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_genParticle->p4.Pz() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterEta", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_genParticle->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterPhi", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_genParticle->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterMass", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_genParticle->p4.mass() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1DaughterCharge", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1DaughterCharge", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].GetCharge() : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterEnergy", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterEnergy", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_genParticle->p4.E() : DefaultValues::UndefinedFloat;
-	});	
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	});
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1DaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
 
 	// second daughter
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterPt", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_genParticle->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterPz", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterPz", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_genParticle->p4.Pz() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterEta", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_genParticle->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterPhi", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_genParticle->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterMass", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_genParticle->p4.mass() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterEnergy", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterEnergy", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_genParticle->p4.E() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2DaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
 
 	// Boson granddaughters
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1DaughterGranddaughterSize", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1DaughterGranddaughterSize", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_daughters.size() : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2DaughterGranddaughterSize", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2DaughterGranddaughterSize", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[1].m_daughters.size() : DefaultValues::UndefinedInt;
 	});
 
 	// first daughter daughters
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter1GranddaughterPt", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter1GranddaughterPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_daughters[0].m_genParticle->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter1GranddaughterPz", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter1GranddaughterPz", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_daughters[0].m_genParticle->p4.Pz() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter1GranddaughterEta", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter1GranddaughterEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_daughters[0].m_genParticle->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter1GranddaughterPhi", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter1GranddaughterPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_daughters[0].m_genParticle->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter1GranddaughterMass", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter1GranddaughterMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_daughters[0].m_genParticle->p4.mass() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter1GranddaughterEnergy", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter1GranddaughterEnergy", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_daughters[0].m_genParticle->p4.E() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter1GranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter1GranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_daughters[0].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter1GranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter1GranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[0].m_daughters[0].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter2GranddaughterPt", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter2GranddaughterPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_genParticle->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter2GranddaughterPz", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter2GranddaughterPz", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_genParticle->p4.Pz() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter2GranddaughterEta", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter2GranddaughterEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_genParticle->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter2GranddaughterPhi", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter2GranddaughterPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_genParticle->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter2GranddaughterMass", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter2GranddaughterMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_genParticle->p4.mass() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter2GranddaughterEnergy", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter2GranddaughterEnergy", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_genParticle->p4.E() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2GranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2GranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2GranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2GranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter3GranddaughterPt", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter3GranddaughterPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[0].m_daughters[2].m_genParticle->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter3GranddaughterPz", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter3GranddaughterPz", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[0].m_daughters[2].m_genParticle->p4.Pz() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter3GranddaughterEta", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter3GranddaughterEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[0].m_daughters[2].m_genParticle->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter3GranddaughterPhi", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter3GranddaughterPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[0].m_daughters[2].m_genParticle->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter3GranddaughterMass", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter3GranddaughterMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[0].m_daughters[2].m_genParticle->p4.mass() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter3GranddaughterEnergy", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter3GranddaughterEnergy", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[0].m_daughters[2].m_genParticle->p4.E() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter3GranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter3GranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[0].m_daughters[2].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter3GranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter3GranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[0].m_daughters[2].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter4GranddaughterPt", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter4GranddaughterPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[0].m_daughters[3].m_genParticle->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter4GranddaughterPz", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter4GranddaughterPz", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[0].m_daughters[3].m_genParticle->p4.Pz() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter4GranddaughterEta", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter4GranddaughterEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[0].m_daughters[3].m_genParticle->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter4GranddaughterPhi", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter4GranddaughterPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[0].m_daughters[3].m_genParticle->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter4GranddaughterMass", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter4GranddaughterMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[0].m_daughters[3].m_genParticle->p4.mass() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter4GranddaughterEnergy", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson1Daughter4GranddaughterEnergy", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[0].m_daughters[3].m_genParticle->p4.E() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter4GranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter4GranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[0].m_daughters[3].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter4GranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter4GranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[0].m_daughters[3].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
 
 	// second daughter daughters
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter1GranddaughterPt", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter1GranddaughterPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[1].m_daughters[0].m_genParticle->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter1GranddaughterPz", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter1GranddaughterPz", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[1].m_daughters[0].m_genParticle->p4.Pz() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter1GranddaughterEta", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter1GranddaughterEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[1].m_daughters[0].m_genParticle->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter1GranddaughterPhi", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter1GranddaughterPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[1].m_daughters[0].m_genParticle->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter1GranddaughterMass", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter1GranddaughterMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[1].m_daughters[0].m_genParticle->p4.mass() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter1GranddaughterEnergy", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter1GranddaughterEnergy", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[1].m_daughters[0].m_genParticle->p4.E() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter1GranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter1GranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[1].m_daughters[0].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter1GranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter1GranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 0) ? product.m_genBosonTree.m_daughters[1].m_daughters[0].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter2GranddaughterPt", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter2GranddaughterPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_daughters[1].m_genParticle->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter2GranddaughterPz", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter2GranddaughterPz", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_daughters[1].m_genParticle->p4.Pz() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter2GranddaughterEta", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter2GranddaughterEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_daughters[1].m_genParticle->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter2GranddaughterPhi", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter2GranddaughterPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_daughters[1].m_genParticle->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter2GranddaughterMass", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter2GranddaughterMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_daughters[1].m_genParticle->p4.mass() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter2GranddaughterEnergy", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter2GranddaughterEnergy", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_daughters[1].m_genParticle->p4.E() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter2GranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter2GranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_daughters[1].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter2GranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter2GranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 1) ? product.m_genBosonTree.m_daughters[1].m_daughters[1].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter3GranddaughterPt", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter3GranddaughterPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[1].m_daughters[2].m_genParticle->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter3GranddaughterPz", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter3GranddaughterPz", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[1].m_daughters[2].m_genParticle->p4.Pz() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter3GranddaughterEta", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter3GranddaughterEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[1].m_daughters[2].m_genParticle->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter3GranddaughterPhi", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter3GranddaughterPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[1].m_daughters[2].m_genParticle->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter3GranddaughterMass", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter3GranddaughterMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[1].m_daughters[2].m_genParticle->p4.mass() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter3GranddaughterEnergy", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter3GranddaughterEnergy", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[1].m_daughters[2].m_genParticle->p4.E() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter3GranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter3GranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[1].m_daughters[2].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter3GranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter3GranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 2) ? product.m_genBosonTree.m_daughters[1].m_daughters[2].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter4GranddaughterPt", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter4GranddaughterPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[1].m_daughters[3].m_genParticle->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter4GranddaughterPz", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter4GranddaughterPz", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[1].m_daughters[3].m_genParticle->p4.Pz() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter4GranddaughterEta", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter4GranddaughterEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[1].m_daughters[3].m_genParticle->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter4GranddaughterPhi", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter4GranddaughterPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[1].m_daughters[3].m_genParticle->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter4GranddaughterMass", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter4GranddaughterMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[1].m_daughters[3].m_genParticle->p4.mass() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter4GranddaughterEnergy", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("1genBoson2Daughter4GranddaughterEnergy", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[1].m_daughters[3].m_genParticle->p4.E() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter4GranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter4GranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[1].m_daughters[3].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter4GranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter4GranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 3) ? product.m_genBosonTree.m_daughters[1].m_daughters[3].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
 
 	// Boson GrandGranddaughters: the only GrandGranddaughters we need are from 2nd Granddaughters
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2GranddaughterGrandGranddaughterSize", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2GranddaughterGrandGranddaughterSize", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >0)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter2GranddaughterGrandGranddaughterSize", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson2Daughter2GranddaughterGrandGranddaughterSize", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[1].m_daughters[1].m_daughters.size() >0)? product.m_genBosonTree.m_daughters[1].m_daughters[1].m_daughters.size() : DefaultValues::UndefinedInt;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter1GrandGranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter1GrandGranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >0)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters[0].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter1GrandGranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter1GrandGranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >0)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters[0].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter2GrandGranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter2GrandGranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >1)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters[1].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter2GrandGranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter2GrandGranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >1)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters[1].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter3GrandGranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter3GrandGranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >2)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters[2].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter3GrandGranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter3GrandGranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >2)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters[2].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter4GrandGranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter4GrandGranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >3)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters[3].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter4GrandGranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter4GrandGranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >3)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters[3].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter5GrandGranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter5GrandGranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >4)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters[4].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter5GrandGranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter5GrandGranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >4)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters[4].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
-	
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter6GrandGranddaughterPdgId", [](KappaEvent const & event, KappaProduct const & product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter6GrandGranddaughterPdgId", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >5)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters[5].m_genParticle->pdgId : DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter6GrandGranddaughterStatus", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("1genBoson1Daughter2Granddaughter6GrandGranddaughterStatus", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return (product.m_genBosonTree.m_daughters.size() > 0) && (product.m_genBosonTree.m_daughters[0].m_daughters.size() > 1) && (product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters.size() >5)? product.m_genBosonTree.m_daughters[0].m_daughters[1].m_daughters[5].m_genParticle->status() : DefaultValues::UndefinedInt;
 	});
@@ -439,14 +439,14 @@ void GenTauDecayProducer::Produce(KappaEvent const& event, KappaProduct& product
                                   KappaSettings const& settings) const
 {
 	assert(event.m_genParticles);
-	
+
 	// A generator level boson or its leptonic decay products must exist
 	// This is searched for by a GenBosonProducer
 	if (product.m_genBosonParticle != nullptr)
 	{
 		product.m_genBosonTree = GenParticleDecayTree(product.m_genBosonParticle);
 		product.m_genTauDecayTrees[product.m_genBosonParticle] = &product.m_genBosonTree;
-		
+
 		if (product.m_genBosonParticle->daughterIndices.empty())
 		{
 			product.m_genBosonTree.m_finalState = true;
@@ -473,14 +473,14 @@ void GenTauDecayProducer::Produce(KappaEvent const& event, KappaProduct& product
 			}
 		}
 	}
-	
+
 	for (std::vector<GenParticleDecayTree>::iterator bosonDecayProduct = product.m_genBosonTree.m_daughters.begin();
 	     bosonDecayProduct != product.m_genBosonTree.m_daughters.end(); ++bosonDecayProduct)
 	{
 		product.m_genTauDecayTrees[bosonDecayProduct->m_genParticle] = &(*bosonDecayProduct);
 	}
 }
-	
+
 void GenTauDecayProducer::BuildDecayTree(GenParticleDecayTree& currentDecayTree, KGenParticle* currentGenParticle, event_type const& event) const
 {
 	for (std::vector<unsigned int>::iterator daughterIndex = currentGenParticle->daughterIndices.begin();

--- a/KappaAnalysis/src/Producers/GenTauJetProducer.cc
+++ b/KappaAnalysis/src/Producers/GenTauJetProducer.cc
@@ -8,8 +8,8 @@ std::string GenTauJetProducer::GetProducerId() const{
 void GenTauJetProducer::Init(KappaSettings const& settings)
 {
 	KappaProducerBase::Init(settings);
-	
-	LambdaNtupleConsumer<KappaTypes>::AddVFloatQuantity("genTauJetVisPt", [](KappaEvent const & event, KappaProduct const & product)
+
+	LambdaNtupleConsumer<KappaTypes>::AddVFloatQuantity("genTauJetVisPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		std::vector<float> genTauJetPt;
 		for (typename std::vector<KGenJet*>::const_iterator genJet = (product.m_genTauJets).begin();
@@ -19,7 +19,7 @@ void GenTauJetProducer::Init(KappaSettings const& settings)
 		}
 		return genTauJetPt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddVFloatQuantity("genTauJetEta", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddVFloatQuantity("genTauJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		std::vector<float> genTauJetEta;
 		for (typename std::vector<KGenJet*>::const_iterator genJet = (product.m_genTauJets).begin();
@@ -29,7 +29,7 @@ void GenTauJetProducer::Init(KappaSettings const& settings)
 		}
 		return genTauJetEta;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddVIntQuantity("genTauJetDM", [](KappaEvent const & event, KappaProduct const & product)
+	LambdaNtupleConsumer<KappaTypes>::AddVIntQuantity("genTauJetDM", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		std::vector<int> genTauJetDM;
 		for (typename std::vector<KGenJet*>::const_iterator genJet = (product.m_genTauJets).begin();
@@ -45,11 +45,11 @@ void GenTauJetProducer::Produce(KappaEvent const& event, KappaProduct& product,
                      KappaSettings const& settings) const
 {
 	assert(event.m_genTauJets);
-	
+
 	for (KGenJets::iterator part = event.m_genTauJets->begin(); part != event.m_genTauJets->end(); ++part)
 	{
 		int decayMode = part->genTauDecayMode;
-		
+
 		// select only 1-prong and 3-prong decay modes
 		if (((decayMode >= 0) && (decayMode <= 4)) || (decayMode == 7) || (decayMode == 8))
 		{

--- a/KappaAnalysis/src/Producers/NicknameProducer.cc
+++ b/KappaAnalysis/src/Producers/NicknameProducer.cc
@@ -12,39 +12,39 @@ void NicknameProducer::Init(KappaSettings const& settings)
 	KappaProducerBase::Init(settings);
 
 	// add possible quantities for the lambda ntuples consumers
-	LambdaNtupleConsumer<KappaTypes>::AddStringQuantity("nickname", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddStringQuantity("nickname", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_nickname;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isMC", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isMC", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_isMC;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isEmbedded", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isEmbedded", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_isEmbedded;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isSingleMuon", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isSingleMuon", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_isSingleMuon;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isSingleElectron", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isSingleElectron", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_isSingleElectron;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isMuonEG", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isMuonEG", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_isMuonEG;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isTau", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isTau", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_isTau;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isDoubleEG", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isDoubleEG", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_isDoubleEG;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isDoubleMuon", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("isDoubleMuon", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_isDoubleMuon;
 	});

--- a/KappaAnalysis/src/Producers/NumberOfParticlesProducer.cc
+++ b/KappaAnalysis/src/Producers/NumberOfParticlesProducer.cc
@@ -6,15 +6,15 @@
 void NumberOfParticlesProducer::Init(KappaSettings const& settings)
 {
 	KappaProducerBase::Init(settings);
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NLooseElectrons", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NLooseElectrons", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_NLooseElectrons;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NLooseElectronsRelaxedVtxCriteria", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NLooseElectronsRelaxedVtxCriteria", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_NLooseElectronsRelaxedVtxCriteria;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NEmbeddingMuons", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NEmbeddingMuons", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_NEmbeddingMuons;
 	});

--- a/KappaAnalysis/src/Producers/PFCandidatesProducer.cc
+++ b/KappaAnalysis/src/Producers/PFCandidatesProducer.cc
@@ -3,31 +3,31 @@
 void PFCandidatesProducer::Init(KappaSettings const& settings)
 {
 	KappaProducerBase::Init(settings);
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFChargedHadrons", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFChargedHadrons", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_pfChargedHadrons.size();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFNeutralHadrons", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFNeutralHadrons", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_pfNeutralHadrons.size();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFElectrons", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFElectrons", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_pfElectrons.size();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFMuons", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFMuons", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_pfMuons.size();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFPhotons", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFPhotons", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_pfPhotons.size();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFHadronicHF", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFHadronicHF", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_pfHadronicHF.size();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFElectromagneticHF", [](KappaEvent const& event, KappaProduct const& product)
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("NPFElectromagneticHF", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings)
 	{
 		return product.m_pfElectromagneticHF.size();
 	});

--- a/KappaAnalysis/src/Producers/ValidBTaggedJetsProducer.cc
+++ b/KappaAnalysis/src/Producers/ValidBTaggedJetsProducer.cc
@@ -26,24 +26,24 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		// define lambda expression for nbtag per working point
 		std::string btagQuantity = std::string("n")+bTagWorkingPoint.first+std::string("btag");
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(btagQuantity, [bTagWorkingPoint](KappaEvent const& event, KappaProduct const& product) {
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(btagQuantity, [bTagWorkingPoint](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 			auto it = product.m_bTaggedJetsByWp.find(bTagWorkingPoint.first);
 			return it != product.m_bTaggedJetsByWp.end() ? product.m_bTaggedJetsByWp.at(bTagWorkingPoint.first).size() : 0;
 		});
 	}
 
 	// add possible quantities for the lambda ntuples consumers
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20", [this](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20", [this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return KappaProduct::GetNJetsAbovePtThreshold(product.m_bTaggedJets, 20.0);
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30", [this](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30", [this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return KappaProduct::GetNJetsAbovePtThreshold(product.m_bTaggedJets, 30.0);
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30TruePassed", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30TruePassed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
@@ -54,7 +54,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30FalsePassed", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30FalsePassed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
@@ -65,7 +65,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30TrueFailed", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30TrueFailed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
@@ -76,7 +76,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30FalseFailed", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30FalseFailed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
@@ -88,7 +88,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		return n;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20TruePassed", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20TruePassed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
@@ -99,7 +99,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20FalsePassed", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20FalsePassed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
@@ -110,7 +110,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20TrueFailed", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20TrueFailed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
@@ -121,69 +121,69 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20FalseFailed", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20FalseFailed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
 		{
 			KJet* tjet = static_cast<KJet*>(*jet);
 			if (tjet->p4.pt() < 20 ) continue;
-			if (tjet->hadronFlavour != 5) n++;
-		}
-		return n;
-	});
-
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsTruePassed", [settings](KappaEvent const& event, KappaProduct const& product) {
-		if (settings.GetInputIsData()) return -1;
-		int n(0);
-		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
-		{
-			KJet* tjet = static_cast<KJet*>(*jet);
-			if (tjet->hadronFlavour == 5) n++;
-		}
-		return n;
-	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsFalsePassed", [settings](KappaEvent const& event, KappaProduct const& product) {
-		if (settings.GetInputIsData()) return -1;
-		int n(0);
-		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
-		{
-			KJet* tjet = static_cast<KJet*>(*jet);
-			if (tjet->hadronFlavour != 5) n++;
-		}
-		return n;
-	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsTrueFailed", [settings](KappaEvent const& event, KappaProduct const& product) {
-		if (settings.GetInputIsData()) return -1;
-		int n(0);
-		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
-		{
-			KJet* tjet = static_cast<KJet*>(*jet);
-			if (tjet->hadronFlavour == 5) n++;
-		}
-		return n;
-	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsFalseFailed", [settings](KappaEvent const& event, KappaProduct const& product) {
-		if (settings.GetInputIsData()) return -1;
-		int n(0);
-		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
-		{
-			KJet* tjet = static_cast<KJet*>(*jet);
 			if (tjet->hadronFlavour != 5) n++;
 		}
 		return n;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJetPt", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsTruePassed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		if (settings.GetInputIsData()) return -1;
+		int n(0);
+		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
+		{
+			KJet* tjet = static_cast<KJet*>(*jet);
+			if (tjet->hadronFlavour == 5) n++;
+		}
+		return n;
+	});
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsFalsePassed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		if (settings.GetInputIsData()) return -1;
+		int n(0);
+		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
+		{
+			KJet* tjet = static_cast<KJet*>(*jet);
+			if (tjet->hadronFlavour != 5) n++;
+		}
+		return n;
+	});
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsTrueFailed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		if (settings.GetInputIsData()) return -1;
+		int n(0);
+		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
+		{
+			KJet* tjet = static_cast<KJet*>(*jet);
+			if (tjet->hadronFlavour == 5) n++;
+		}
+		return n;
+	});
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsFalseFailed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+		if (settings.GetInputIsData()) return -1;
+		int n(0);
+		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
+		{
+			KJet* tjet = static_cast<KJet*>(*jet);
+			if (tjet->hadronFlavour != 5) n++;
+		}
+		return n;
+	});
+
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size() >= 1 ? product.m_bTaggedJets.at(0)->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJetEta", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size() >= 1 ? product.m_bTaggedJets.at(0)->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJetPhi", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size() >= 1 ? product.m_bTaggedJets.at(0)->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("bJetIsTrueBJet", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("bJetIsTrueBJet", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return DefaultValues::UndefinedInt;
 		if (product.m_bTaggedJets.size() >= 1) {
 			if (product.m_bTaggedJets.at(0)->hadronFlavour == 5) {
@@ -192,19 +192,19 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 			else {
 				return 0;
 			}
-		} 
+		}
 		else return DefaultValues::UndefinedInt;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJet2Pt", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJet2Pt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size() >= 2 ? product.m_bTaggedJets.at(1)->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJet2Eta", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJet2Eta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size() >= 2 ? product.m_bTaggedJets.at(1)->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJet2Phi", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJet2Phi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size() >= 2 ? product.m_bTaggedJets.at(1)->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("bJet2IsTrueBJet", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("bJet2IsTrueBJet", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return DefaultValues::UndefinedInt;
 		if (product.m_bTaggedJets.size() >= 2) {
 			if (product.m_bTaggedJets.at(1)->hadronFlavour == 5) {
@@ -213,23 +213,23 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 			else {
 				return 0;
 			}
-		} 
+		}
 		else return DefaultValues::UndefinedInt;
 	});
 
 	std::string bTaggedJetCSVName = settings.GetBTaggedJetCombinedSecondaryVertexName();
 	std::string jetPuJetIDName = settings.GetPuJetIDFullDiscrName();
 
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingBJetCSV",[bTaggedJetCSVName](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingBJetCSV",[bTaggedJetCSVName](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size() >= 1 ? static_cast<KJet*>(product.m_bTaggedJets.at(0))->getTag(bTaggedJetCSVName, event.m_jetMetadata) : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingBJetPuID",[jetPuJetIDName](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingBJetPuID",[jetPuJetIDName](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size() >= 1 ? static_cast<KJet*>(product.m_bTaggedJets.at(0))->getTag(jetPuJetIDName, event.m_jetMetadata) : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingBJetCSV",[bTaggedJetCSVName](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingBJetCSV",[bTaggedJetCSVName](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size() >= 2 ? static_cast<KJet*>(product.m_bTaggedJets.at(1))->getTag(bTaggedJetCSVName, event.m_jetMetadata) : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingBJetPuID",[jetPuJetIDName](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingBJetPuID",[jetPuJetIDName](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size() >= 2 ? static_cast<KJet*>(product.m_bTaggedJets.at(1))->getTag(jetPuJetIDName, event.m_jetMetadata) : DefaultValues::UndefinedFloat;
 	});
 }

--- a/KappaAnalysis/src/Producers/ValidBTaggedJetsProducer.cc
+++ b/KappaAnalysis/src/Producers/ValidBTaggedJetsProducer.cc
@@ -43,7 +43,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		return KappaProduct::GetNJetsAbovePtThreshold(product.m_bTaggedJets, 30.0);
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30TruePassed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30TruePassed", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
@@ -54,7 +54,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30FalsePassed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30FalsePassed", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
@@ -65,7 +65,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30TrueFailed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30TrueFailed", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
@@ -76,7 +76,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30FalseFailed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets30FalseFailed", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
@@ -88,7 +88,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		return n;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20TruePassed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20TruePassed", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
@@ -99,7 +99,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20FalsePassed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20FalsePassed", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
@@ -110,7 +110,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20TrueFailed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20TrueFailed", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
@@ -121,7 +121,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20FalseFailed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJets20FalseFailed", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
@@ -133,7 +133,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		return n;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsTruePassed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsTruePassed", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
@@ -143,7 +143,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsFalsePassed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsFalsePassed", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_bTaggedJets.begin(); jet != product.m_bTaggedJets.end(); ++jet)
@@ -153,7 +153,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsTrueFailed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsTrueFailed", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
@@ -163,7 +163,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 		}
 		return n;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsFalseFailed", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nBJetsFalseFailed", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return -1;
 		int n(0);
 		for (auto jet = product.m_nonBTaggedJets.begin(); jet != product.m_nonBTaggedJets.end(); ++jet)
@@ -183,7 +183,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size() >= 1 ? product.m_bTaggedJets.at(0)->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("bJetIsTrueBJet", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("bJetIsTrueBJet", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return DefaultValues::UndefinedInt;
 		if (product.m_bTaggedJets.size() >= 1) {
 			if (product.m_bTaggedJets.at(0)->hadronFlavour == 5) {
@@ -204,7 +204,7 @@ void ValidBTaggedJetsProducer::Init(KappaSettings const& settings)
 	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("bJet2Phi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_bTaggedJets.size() >= 2 ? product.m_bTaggedJets.at(1)->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("bJet2IsTrueBJet", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("bJet2IsTrueBJet", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return DefaultValues::UndefinedInt;
 		if (product.m_bTaggedJets.size() >= 2) {
 			if (product.m_bTaggedJets.at(1)->hadronFlavour == 5) {

--- a/KappaAnalysis/src/Producers/ValidGenJetsProducer.cc
+++ b/KappaAnalysis/src/Producers/ValidGenJetsProducer.cc
@@ -25,115 +25,115 @@ void ValidGenJetsProducer::Init(KappaSettings const& settings)
 	ValidPhysicsObjectTools<KappaTypes, KGenJet>::Init(settings);
 
 	// add possible quantities for the lambda ntuples consumers
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nGenJets", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nGenJets", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size();
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nGenJets20",[this](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nGenJets20",[this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return KappaProduct::GetNJetsAbovePtThreshold(product.m_validGenJets, 20.0);
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nGenJets30",[this](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nGenJets30",[this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return KappaProduct::GetNJetsAbovePtThreshold(product.m_validGenJets, 30.0);
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nGenJets50",[this](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nGenJets50",[this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return KappaProduct::GetNJetsAbovePtThreshold(product.m_validGenJets, 50.0);
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nGenJets80",[this](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("nGenJets80",[this](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return KappaProduct::GetNJetsAbovePtThreshold(product.m_validGenJets, 80.0);
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingGenJetLV", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("leadingGenJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 1 ? product.m_validGenJets.at(0)->p4 : DefaultValues::UndefinedRMFLV;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingGenJetPt", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingGenJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 1 ? product.m_validGenJets.at(0)->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingGenJetEta", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingGenJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 1 ? product.m_validGenJets.at(0)->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingGenJetPhi", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingGenJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 1 ? product.m_validGenJets.at(0)->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingGenJetMass", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingGenJetMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 1 ? product.m_validGenJets.at(0)->p4.mass() : DefaultValues::UndefinedFloat;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("trailingGenJetLV", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("trailingGenJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 2 ? product.m_validGenJets.at(1)->p4 : DefaultValues::UndefinedRMFLV;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingGenJetPt", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingGenJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 2 ? product.m_validGenJets.at(1)->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingGenJetEta", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingGenJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 2 ? product.m_validGenJets.at(1)->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingGenJetPhi", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingGenJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 2 ? product.m_validGenJets.at(1)->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingGenJetMass", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingGenJetMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 2 ? product.m_validGenJets.at(1)->p4.mass() : DefaultValues::UndefinedFloat;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("thirdGenJetLV", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("thirdGenJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 3 ? product.m_validGenJets.at(2)->p4 : DefaultValues::UndefinedRMFLV;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdGenJetPt", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdGenJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 3 ? product.m_validGenJets.at(2)->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdGenJetEta", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdGenJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 3 ? product.m_validGenJets.at(2)->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdGenJetPhi", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdGenJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 3 ? product.m_validGenJets.at(2)->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdGenJetMass", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdGenJetMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 3 ? product.m_validGenJets.at(2)->p4.mass() : DefaultValues::UndefinedFloat;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("fourthGenJetLV", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("fourthGenJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 4 ? product.m_validGenJets.at(3)->p4 : DefaultValues::UndefinedRMFLV;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthGenJetPt", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthGenJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 4 ? product.m_validGenJets.at(3)->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthGenJetEta", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthGenJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 4 ? product.m_validGenJets.at(3)->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthGenJetPhi", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthGenJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 4 ? product.m_validGenJets.at(3)->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthGenJetMass", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthGenJetMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 4 ? product.m_validGenJets.at(3)->p4.mass() : DefaultValues::UndefinedFloat;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("fifthGenJetLV", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("fifthGenJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 5 ? product.m_validGenJets.at(4)->p4 : DefaultValues::UndefinedRMFLV;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthGenJetPt", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthGenJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 5 ? product.m_validGenJets.at(4)->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthGenJetEta", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthGenJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 5 ? product.m_validGenJets.at(4)->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthGenJetPhi", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthGenJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 5 ? product.m_validGenJets.at(4)->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthGenJetMass", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fifthGenJetMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 5 ? product.m_validGenJets.at(4)->p4.mass() : DefaultValues::UndefinedFloat;
 	});
 
-	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("sixthGenJetLV", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity("sixthGenJetLV", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 6 ? product.m_validGenJets.at(5)->p4 : DefaultValues::UndefinedRMFLV;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthGenJetPt", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthGenJetPt", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 6 ? product.m_validGenJets.at(5)->p4.Pt() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthGenJetEta", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthGenJetEta", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 6 ? product.m_validGenJets.at(5)->p4.Eta() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthGenJetPhi", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthGenJetPhi", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 6 ? product.m_validGenJets.at(5)->p4.Phi() : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthGenJetMass", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("sixthGenJetMass", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validGenJets.size() >= 6 ? product.m_validGenJets.at(5)->p4.mass() : DefaultValues::UndefinedFloat;
 	});
 }
@@ -141,12 +141,12 @@ void ValidGenJetsProducer::Init(KappaSettings const& settings)
 void ValidGenJetsProducer::Produce(KappaEvent const& event, KappaProduct& product, KappaSettings const& settings) const
 {
 	assert(event.m_genJets);
-	
+
 	for (std::vector<KGenJet>::iterator jet = event.m_genJets->begin();
 	     jet != event.m_genJets->end(); ++jet)
 	{
 		bool validJet = true;
-		
+
 		// remove leptons from list of jets via simple DeltaR isolation
 		for (std::vector<KGenParticle*>::iterator lepton = product.m_genLeptonsFromBosonDecay.begin();
 		     lepton != product.m_genLeptonsFromBosonDecay.end(); ++lepton)
@@ -160,7 +160,7 @@ void ValidGenJetsProducer::Produce(KappaEvent const& event, KappaProduct& produc
 					visibleP4 = &(genTau->visible.p4);
 				}
 			}
-			
+
 			validJet = validJet && ROOT::Math::VectorUtil::DeltaR(jet->p4, *visibleP4) > settings.GetJetLeptonLowerDeltaRCut();
 		}
 

--- a/KappaAnalysis/src/Producers/ValidGenParticlesProducers.cc
+++ b/KappaAnalysis/src/Producers/ValidGenParticlesProducers.cc
@@ -32,29 +32,29 @@ void ValidGenParticlesProducer::Init(KappaSettings const& settings)
 	for (size_t leptonIndex = 0; leptonIndex < 2; ++leptonIndex)
 	{
 		std::string quantityNameBase = "gen" + m_name + std::to_string(leptonIndex+1);
-		
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity(quantityNameBase+"Pt", [this, leptonIndex](event_type const& event, product_type const& product)
+
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity(quantityNameBase+"Pt", [this, leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (((product.*m_validLeptonsMember).size() > leptonIndex) ? (product.*m_validLeptonsMember)[leptonIndex]->p4.Pt() : DefaultValues::UndefinedFloat);
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity(quantityNameBase+"Eta", [this, leptonIndex](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity(quantityNameBase+"Eta", [this, leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (((product.*m_validLeptonsMember).size() > leptonIndex) ? (product.*m_validLeptonsMember)[leptonIndex]->p4.Eta() : DefaultValues::UndefinedFloat);
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity(quantityNameBase+"Phi", [this, leptonIndex](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity(quantityNameBase+"Phi", [this, leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (((product.*m_validLeptonsMember).size() > leptonIndex) ? (product.*m_validLeptonsMember)[leptonIndex]->p4.Phi() : DefaultValues::UndefinedFloat);
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity(quantityNameBase+"Mass", [this, leptonIndex](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity(quantityNameBase+"Mass", [this, leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (((product.*m_validLeptonsMember).size() > leptonIndex) ? (product.*m_validLeptonsMember)[leptonIndex]->p4.mass() : DefaultValues::UndefinedFloat);
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity(quantityNameBase+"Charge", [this, leptonIndex](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity(quantityNameBase+"Charge", [this, leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (((product.*m_validLeptonsMember).size() > leptonIndex) ? (product.*m_validLeptonsMember)[leptonIndex]->charge() : DefaultValues::UndefinedFloat);
 		});
-		
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity(quantityNameBase+"LV", [this, leptonIndex](event_type const& event, product_type const& product)
+
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity(quantityNameBase+"LV", [this, leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (((product.*m_validLeptonsMember).size() > leptonIndex) ? (product.*m_validLeptonsMember)[leptonIndex]->p4 : DefaultValues::UndefinedRMFLV);
 		});
@@ -67,13 +67,13 @@ void ValidGenParticlesProducer::Produce(event_type const& event, product_type& p
 	     genParticle != (product.*m_genParticlesMember).end();)
 	{
 		bool validLepton = (std::abs((*genParticle)->pdgId) == m_absPdgId);
-		
+
 		// kinematic cuts
 		validLepton = validLepton && this->PassKinematicCuts(*genParticle, event, product);
-		
+
 		// check possible analysis-specific criteria
 		validLepton = validLepton && AdditionalCriteria(*genParticle, event, product, settings);
-		
+
 		if (validLepton)
 		{
 			(product.*m_validLeptonsMember).push_back(*genParticle);
@@ -84,7 +84,7 @@ void ValidGenParticlesProducer::Produce(event_type const& event, product_type& p
 			++genParticle; // genParticle = (product.*m_genParticlesMember).erase(genParticle);
 		}
 	}
-	
+
 	// preserve Pt sorting of valid gen. leptons
 	std::sort(
 			(product.*m_validLeptonsMember).begin(),
@@ -174,21 +174,21 @@ void ValidGenTausProducer::Init(KappaSettings const& settings)
 	for (size_t leptonIndex = 0; leptonIndex < 2; ++leptonIndex)
 	{
 		std::string quantityNameBase = "gen" + m_name + std::to_string(leptonIndex+1);
-		
-		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity(quantityNameBase+"VisibleLV", [this, leptonIndex](event_type const& event, product_type const& product)
+
+		LambdaNtupleConsumer<KappaTypes>::AddRMFLVQuantity(quantityNameBase+"VisibleLV", [this, leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (((product.*m_validLeptonsMember).size() > leptonIndex) ? static_cast<KGenTau*>((product.*m_validLeptonsMember)[leptonIndex])->visible.p4 : DefaultValues::UndefinedRMFLV);
 		});
-		
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(quantityNameBase+"DecayMode", [this, leptonIndex](event_type const& event, product_type const& product)
+
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(quantityNameBase+"DecayMode", [this, leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (((product.*m_validLeptonsMember).size() > leptonIndex) ? static_cast<KGenTau*>((product.*m_validLeptonsMember)[leptonIndex])->genDecayMode() : DefaultValues::UndefinedInt);
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(quantityNameBase+"NProngs", [this, leptonIndex](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(quantityNameBase+"NProngs", [this, leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (((product.*m_validLeptonsMember).size() > leptonIndex) ? static_cast<KGenTau*>((product.*m_validLeptonsMember)[leptonIndex])->nProngs : DefaultValues::UndefinedInt);
 		});
-		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(quantityNameBase+"NPi0s", [this, leptonIndex](event_type const& event, product_type const& product)
+		LambdaNtupleConsumer<KappaTypes>::AddIntQuantity(quantityNameBase+"NPi0s", [this, leptonIndex](event_type const& event, product_type const& product, setting_type const& settings)
 		{
 			return (((product.*m_validLeptonsMember).size() > leptonIndex) ? static_cast<KGenTau*>((product.*m_validLeptonsMember)[leptonIndex])->nPi0s : DefaultValues::UndefinedInt);
 		});
@@ -198,7 +198,7 @@ void ValidGenTausProducer::Init(KappaSettings const& settings)
 void ValidGenTausProducer::Produce(event_type const& event, product_type& product, KappaSettings const& settings) const
 {
 	ValidGenParticlesProducer::Produce(event, product, settings);
-	
+
 	// matching of KGenParticle to KGenTau
 	for (std::vector<KGenParticle*>::iterator genParticle = (product.*m_validLeptonsMember).begin();
 	     genParticle != (product.*m_validLeptonsMember).end(); ++genParticle)
@@ -206,7 +206,7 @@ void ValidGenTausProducer::Produce(event_type const& event, product_type& produc
 		float minAbsDeltaR = std::numeric_limits<float>::max();
 		float minAbsDeltaPt = std::numeric_limits<float>::max();
 		KGenTau* bestMatchingGenTau = nullptr;
-		
+
 		for (std::vector<KGenTau>::iterator genTau = event.m_genTaus->begin();
 		     genTau != event.m_genTaus->end(); ++genTau)
 		{

--- a/KappaAnalysis/src/Producers/ValidJetsProducer.cc
+++ b/KappaAnalysis/src/Producers/ValidJetsProducer.cc
@@ -60,7 +60,7 @@ void ValidTaggedJetsProducer::Init(KappaSettings const& settings)
 	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("leadingJetGenMatch", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 1 ? static_cast<KJet*>(product.m_validJets.at(0))->genMatch : false;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("leadingJetHadronFlavour", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("leadingJetHadronFlavour", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return 0;
 		return product.m_validJets.size() >= 1 ? static_cast<KJet*>(product.m_validJets.at(0))->hadronFlavour : false;
 	});
@@ -76,7 +76,7 @@ void ValidTaggedJetsProducer::Init(KappaSettings const& settings)
 	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("trailingJetGenMatch", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 2 ? static_cast<KJet*>(product.m_validJets.at(1))->genMatch : false;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("trailingJetHadronFlavour", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("trailingJetHadronFlavour", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return 0;
 		return product.m_validJets.size() >= 2 ? static_cast<KJet*>(product.m_validJets.at(1))->hadronFlavour : false;
 	});
@@ -86,7 +86,7 @@ void ValidTaggedJetsProducer::Init(KappaSettings const& settings)
 	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("thirdJetGenMatch", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 3 ? static_cast<KJet*>(product.m_validJets.at(2))->genMatch : false;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("thirdJetHadronFlavour", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("thirdJetHadronFlavour", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return 0;
 		return product.m_validJets.size() >= 3 ? static_cast<KJet*>(product.m_validJets.at(2))->hadronFlavour : false;
 	});
@@ -96,7 +96,7 @@ void ValidTaggedJetsProducer::Init(KappaSettings const& settings)
 	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("forthJetGenMatch", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 4? static_cast<KJet*>(product.m_validJets.at(3))->genMatch : false;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("fourthJetHadronFlavour", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("fourthJetHadronFlavour", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return 0;
 		return product.m_validJets.size() >= 4 ? static_cast<KJet*>(product.m_validJets.at(3))->hadronFlavour : false;
 	});

--- a/KappaAnalysis/src/Producers/ValidJetsProducer.cc
+++ b/KappaAnalysis/src/Producers/ValidJetsProducer.cc
@@ -48,55 +48,55 @@ void ValidTaggedJetsProducer::Init(KappaSettings const& settings)
 	std::string bTaggedJetTCHEName = settings.GetBTaggedJetTrackCountingHighEffName();
 	std::string jetPuJetIDName = settings.GetPuJetIDFullDiscrName();
 
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetCSV",[bTaggedJetCSVName](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetCSV",[bTaggedJetCSVName](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 1 ? static_cast<KJet*>(product.m_validJets.at(0))->getTag(bTaggedJetCSVName, event.m_jetMetadata) : DefaultValues::UndefinedFloat;
 	} );
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetTCHE",[bTaggedJetTCHEName](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetTCHE",[bTaggedJetTCHEName](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 1 ? static_cast<KJet*>(product.m_validJets.at(0))->getTag(bTaggedJetTCHEName, event.m_jetMetadata) : DefaultValues::UndefinedFloat;
 	} );
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetPuID",[jetPuJetIDName](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("leadingJetPuID",[jetPuJetIDName](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 1 ? static_cast<KJet*>(product.m_validJets.at(0))->getTag(jetPuJetIDName, event.m_jetMetadata) : DefaultValues::UndefinedFloat;
 	} );
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("leadingJetGenMatch", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("leadingJetGenMatch", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 1 ? static_cast<KJet*>(product.m_validJets.at(0))->genMatch : false;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("leadingJetHadronFlavour", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("leadingJetHadronFlavour", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return 0;
 		return product.m_validJets.size() >= 1 ? static_cast<KJet*>(product.m_validJets.at(0))->hadronFlavour : false;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetCSV",[bTaggedJetCSVName](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetCSV",[bTaggedJetCSVName](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 2 ? static_cast<KJet*>(product.m_validJets.at(1))->getTag(bTaggedJetCSVName, event.m_jetMetadata) : DefaultValues::UndefinedFloat;
 	} );
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetTCHE",[bTaggedJetTCHEName](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetTCHE",[bTaggedJetTCHEName](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 2 ? static_cast<KJet*>(product.m_validJets.at(1))->getTag(bTaggedJetTCHEName, event.m_jetMetadata) : DefaultValues::UndefinedFloat;
 	} );
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetPuID",[jetPuJetIDName](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("trailingJetPuID",[jetPuJetIDName](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 2 ? static_cast<KJet*>(product.m_validJets.at(1))->getTag(jetPuJetIDName, event.m_jetMetadata) : DefaultValues::UndefinedFloat;
 	} );
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("trailingJetGenMatch", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("trailingJetGenMatch", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 2 ? static_cast<KJet*>(product.m_validJets.at(1))->genMatch : false;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("trailingJetHadronFlavour", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("trailingJetHadronFlavour", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return 0;
 		return product.m_validJets.size() >= 2 ? static_cast<KJet*>(product.m_validJets.at(1))->hadronFlavour : false;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetCSV",[bTaggedJetCSVName](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("thirdJetCSV",[bTaggedJetCSVName](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 3 ? static_cast<KJet*>(product.m_validJets.at(2))->getTag(bTaggedJetCSVName, event.m_jetMetadata) : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("thirdJetGenMatch", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("thirdJetGenMatch", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 3 ? static_cast<KJet*>(product.m_validJets.at(2))->genMatch : false;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("thirdJetHadronFlavour", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("thirdJetHadronFlavour", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return 0;
 		return product.m_validJets.size() >= 3 ? static_cast<KJet*>(product.m_validJets.at(2))->hadronFlavour : false;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetCSV",[bTaggedJetCSVName](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddFloatQuantity("fourthJetCSV",[bTaggedJetCSVName](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 4 ? static_cast<KJet*>(product.m_validJets.at(3))->getTag(bTaggedJetCSVName, event.m_jetMetadata) : DefaultValues::UndefinedFloat;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("forthJetGenMatch", [](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddBoolQuantity("forthJetGenMatch", [](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		return product.m_validJets.size() >= 4? static_cast<KJet*>(product.m_validJets.at(3))->genMatch : false;
 	});
-	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("fourthJetHadronFlavour", [settings](KappaEvent const& event, KappaProduct const& product) {
+	LambdaNtupleConsumer<KappaTypes>::AddIntQuantity("fourthJetHadronFlavour", [settings](KappaEvent const& event, KappaProduct const& product, KappaSettings const& settings) {
 		if (settings.GetInputIsData()) return 0;
 		return product.m_validJets.size() >= 4 ? static_cast<KJet*>(product.m_validJets.at(3))->hadronFlavour : false;
 	});

--- a/KappaAnalysisExample/src/DiMuonSystemProducer.cc
+++ b/KappaAnalysisExample/src/DiMuonSystemProducer.cc
@@ -12,18 +12,18 @@ std::string DiMuonSystemProducer::GetProducerId() const
 void DiMuonSystemProducer::Init(setting_type const& settings)
 {
 	ProducerBase<KappaExampleTypes>::Init(settings);
-	
+
 	// add possible quantities for the lambda ntuples consumers
-	LambdaNtupleConsumer<KappaExampleTypes>::AddFloatQuantity("diMuonPt", [](event_type const& event, product_type const& product) {
+	LambdaNtupleConsumer<KappaExampleTypes>::AddFloatQuantity("diMuonPt", [](event_type const& event, product_type const& product, setting_type const& settings) {
 		return product.m_diMuonSystem.Pt();
 	});
-	LambdaNtupleConsumer<KappaExampleTypes>::AddFloatQuantity("diMuonEta", [](event_type const& event, product_type const& product) {
+	LambdaNtupleConsumer<KappaExampleTypes>::AddFloatQuantity("diMuonEta", [](event_type const& event, product_type const& product, setting_type const& settings) {
 		return product.m_diMuonSystem.Eta();
 	});
-	LambdaNtupleConsumer<KappaExampleTypes>::AddFloatQuantity("diMuonPhi", [](event_type const& event, product_type const& product) {
+	LambdaNtupleConsumer<KappaExampleTypes>::AddFloatQuantity("diMuonPhi", [](event_type const& event, product_type const& product, setting_type const& settings) {
 		return product.m_diMuonSystem.Phi();
 	});
-	LambdaNtupleConsumer<KappaExampleTypes>::AddFloatQuantity("diMuonMass", [](event_type const& event, product_type const& product) {
+	LambdaNtupleConsumer<KappaExampleTypes>::AddFloatQuantity("diMuonMass", [](event_type const& event, product_type const& product, setting_type const& settings) {
 		return product.m_diMuonSystem.mass();
 	});
 }
@@ -34,7 +34,7 @@ void DiMuonSystemProducer::Produce(event_type const& event, product_type& produc
 	// make sure that there are at least two muons reconstructed
 	// this should be ensured by a muon counting filter before running this producer
 	assert(product.m_validMuons.size() >= 2);
-	
+
 	// determine the di-muon system and write it to the product
 	product.m_diMuonSystem = (product.m_validMuons[0]->p4 + product.m_validMuons[1]->p4);
 }


### PR DESCRIPTION
This PR would need adjustment also in HTT (https://github.com/KIT-CMS/KITHiggsToTauTau/pull/30). The main change is not to pass a copy of settings to each lambda function (this results in using a bit less RAM). Jets producers are switch to use shared pointers to avoid memory leaks. Some virtual destructors added where needed to avoid warnings during compilation (and potential memory leaks).