### PR TITLE
[ValidJetsProducer] Added JetID for UL2017 and fixed 2017 and 2018 ID

### DIFF
--- a/KappaAnalysis/interface/KappaEnumTypes.h
+++ b/KappaAnalysis/interface/KappaEnumTypes.h
@@ -72,6 +72,7 @@ public:
 		ID2016 = 7,  // new jet ID for 2016 updated on 2017-03-24
 		ID2017 = 8,  // new jet ID for 2017 updated on 2018-02-14
 		ID2018 = 9,  // new jet ID for 2018 updated on 2019-02-02
+		IDUL2017 = 10, // new jet ID for 2017 UL campaign
 	};
 	static JetIDVersion ToJetIDVersion(std::string const& jetIDVersion);
 

--- a/KappaAnalysis/interface/KappaEnumTypes.h
+++ b/KappaAnalysis/interface/KappaEnumTypes.h
@@ -19,7 +19,7 @@ public:
 		GENTAU = 3
 	};
 	static GenParticleType ToGenParticleType(std::string const& genParticleName);
-	
+
 	enum class TauTauDecayMode : int
 	{
 		NONE = -1,
@@ -72,7 +72,9 @@ public:
 		ID2016 = 7,  // new jet ID for 2016 updated on 2017-03-24
 		ID2017 = 8,  // new jet ID for 2017 updated on 2018-02-14
 		ID2018 = 9,  // new jet ID for 2018 updated on 2019-02-02
-		IDUL2017 = 10, // new jet ID for 2017 UL campaign
+		IDUL2016 = 10, // new jet ID for 2016 UL campaign
+		IDUL2017 = 11, // new jet ID for 2017 UL campaign
+		IDUL2018 = 12, // new jet ID for 2018 UL campaign
 	};
 	static JetIDVersion ToJetIDVersion(std::string const& jetIDVersion);
 

--- a/KappaAnalysis/interface/KappaEnumTypes.h
+++ b/KappaAnalysis/interface/KappaEnumTypes.h
@@ -72,9 +72,9 @@ public:
 		ID2016 = 7,  // new jet ID for 2016 updated on 2017-03-24
 		ID2017 = 8,  // new jet ID for 2017 updated on 2018-02-14
 		ID2018 = 9,  // new jet ID for 2018 updated on 2019-02-02
-		IDUL2016 = 10, // new jet ID for 2016 UL campaign
-		IDUL2017 = 11, // new jet ID for 2017 UL campaign
-		IDUL2018 = 12, // new jet ID for 2018 UL campaign
+		ID2016UL = 10, // new jet ID for 2016 UL campaign
+		ID2017UL = 11, // new jet ID for 2017 UL campaign
+		ID2018UL = 12, // new jet ID for 2018 UL campaign
 	};
 	static JetIDVersion ToJetIDVersion(std::string const& jetIDVersion);
 

--- a/KappaAnalysis/interface/Producers/ValidJetsProducer.h
+++ b/KappaAnalysis/interface/Producers/ValidJetsProducer.h
@@ -277,14 +277,18 @@ public:
 		}
 		else if ((jetIDVersion == KappaEnumTypes::JetIDVersion::ID2017 && jetID == KappaEnumTypes::JetID::TIGHT) ||
 		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018 && jetID == KappaEnumTypes::JetID::TIGHT) ||
-				 (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017 && jetID == KappaEnumTypes::JetID::TIGHT))
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2016 && jetID == KappaEnumTypes::JetID::TIGHT) ||
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017 && jetID == KappaEnumTypes::JetID::TIGHT) ||
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2018 && jetID == KappaEnumTypes::JetID::TIGHT))
 		{
 			maxMuFraction = -1.0f;
 			maxCEMFraction = -1.0f;
 		}
 		else if ((jetIDVersion == KappaEnumTypes::JetIDVersion::ID2017 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO) ||
 		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO) ||
-				 (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO))
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2016 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO) ||
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO) ||
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2018 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO))
 		{
 			maxMuFraction = 0.8f,
 			maxCEMFraction = 0.8f;
@@ -299,9 +303,11 @@ public:
 		// |eta| < 2.7
 		if (std::abs(jet->p4.eta()) <= 2.7f)
 		{
-			// 2018 and UL2017 ID only: modified criteria for 2.6 < |eta| <= 2.7
+			// 2018 and UL2016-18 ID only: modified criteria for 2.6 < |eta| <= 2.7
 			if ((jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018) ||
-				(jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017))
+			    (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2016) ||
+			    (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017) ||
+			    (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2018))
 			{
 				// |eta| < 2.6
 				if (std::abs(jet->p4.eta()) < 2.6f)
@@ -373,11 +379,13 @@ public:
 				           (jet->photonFraction + jet->hfEMFraction > 0.02f) &&
 				           (jet->nConstituents - jet->nCharged > 2);
 			}
-			else if (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017)
+			else if (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2016 ||
+			         jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017 ||
+			         jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2018)
 			{
 				validJet = (jet->photonFraction + jet->hfEMFraction < 0.99f) &&
 				           (jet->photonFraction + jet->hfEMFraction > 0.01f) &&
-				           (jet->nConstituents - jet->nCharged > 2);
+				           (jet->nConstituents - jet->nCharged > 1);
 			}
 		}
 
@@ -401,7 +409,9 @@ public:
 				           (jet->neutralHadronFraction > 0.2f) &&
 				           (jet->nConstituents - jet->nCharged > 10);
 			}
-			else if (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017)
+			else if (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2016 ||
+			         jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017 ||
+			         jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2018)
 			{
 				validJet = (jet->photonFraction + jet->hfEMFraction < 0.90f) &&
 				           (jet->neutralHadronFraction > 0.2f) &&

--- a/KappaAnalysis/interface/Producers/ValidJetsProducer.h
+++ b/KappaAnalysis/interface/Producers/ValidJetsProducer.h
@@ -276,13 +276,15 @@ public:
 			maxCEMFraction = maxFraction;
 		}
 		else if ((jetIDVersion == KappaEnumTypes::JetIDVersion::ID2017 && jetID == KappaEnumTypes::JetID::TIGHT) ||
-		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018 && jetID == KappaEnumTypes::JetID::TIGHT))
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018 && jetID == KappaEnumTypes::JetID::TIGHT) ||
+				 (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017 && jetID == KappaEnumTypes::JetID::TIGHT))
 		{
 			maxMuFraction = -1.0f;
 			maxCEMFraction = -1.0f;
 		}
 		else if ((jetIDVersion == KappaEnumTypes::JetIDVersion::ID2017 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO) ||
-		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO))
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO) ||
+				 (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO))
 		{
 			maxMuFraction = 0.8f,
 			maxCEMFraction = 0.8f;
@@ -297,8 +299,9 @@ public:
 		// |eta| < 2.7
 		if (std::abs(jet->p4.eta()) <= 2.7f)
 		{
-			// 2018 ID only: modified criteria for 2.6 < |eta| <= 2.7
-			if (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018)
+			// 2018 and UL2017 ID only: modified criteria for 2.6 < |eta| <= 2.7
+			if ((jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018) ||
+				(jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017))
 			{
 				// |eta| < 2.6
 				if (std::abs(jet->p4.eta()) < 2.6f)
@@ -370,6 +373,12 @@ public:
 				           (jet->photonFraction + jet->hfEMFraction > 0.02f) &&
 				           (jet->nConstituents - jet->nCharged > 2);
 			}
+			else if (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017)
+			{
+				validJet = (jet->photonFraction + jet->hfEMFraction < 0.99f) &&
+				           (jet->photonFraction + jet->hfEMFraction > 0.01f) &&
+				           (jet->nConstituents - jet->nCharged > 2);
+			}
 		}
 
 		// 3.0 < |eta|
@@ -389,7 +398,13 @@ public:
 			else if (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2017 || jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018)
 			{
 				validJet = (jet->photonFraction + jet->hfEMFraction < 0.90f) &&
-				           (jet->neutralHadronFraction > 0.02f) &&
+				           (jet->neutralHadronFraction > 0.2f) &&
+				           (jet->nConstituents - jet->nCharged > 10);
+			}
+			else if (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017)
+			{
+				validJet = (jet->photonFraction + jet->hfEMFraction < 0.90f) &&
+				           (jet->neutralHadronFraction > 0.2f) &&
 				           (jet->nConstituents - jet->nCharged > 10);
 			}
 		}

--- a/KappaAnalysis/interface/Producers/ValidJetsProducer.h
+++ b/KappaAnalysis/interface/Producers/ValidJetsProducer.h
@@ -277,18 +277,18 @@ public:
 		}
 		else if ((jetIDVersion == KappaEnumTypes::JetIDVersion::ID2017 && jetID == KappaEnumTypes::JetID::TIGHT) ||
 		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018 && jetID == KappaEnumTypes::JetID::TIGHT) ||
-		         (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2016 && jetID == KappaEnumTypes::JetID::TIGHT) ||
-		         (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017 && jetID == KappaEnumTypes::JetID::TIGHT) ||
-		         (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2018 && jetID == KappaEnumTypes::JetID::TIGHT))
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2016UL && jetID == KappaEnumTypes::JetID::TIGHT) ||
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2017UL && jetID == KappaEnumTypes::JetID::TIGHT) ||
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018UL && jetID == KappaEnumTypes::JetID::TIGHT))
 		{
 			maxMuFraction = -1.0f;
 			maxCEMFraction = -1.0f;
 		}
 		else if ((jetIDVersion == KappaEnumTypes::JetIDVersion::ID2017 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO) ||
 		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO) ||
-		         (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2016 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO) ||
-		         (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO) ||
-		         (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2018 && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO))
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2016UL && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO) ||
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2017UL && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO) ||
+		         (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018UL && jetID == KappaEnumTypes::JetID::TIGHTLEPVETO))
 		{
 			maxMuFraction = 0.8f,
 			maxCEMFraction = 0.8f;
@@ -303,11 +303,11 @@ public:
 		// |eta| < 2.7
 		if (std::abs(jet->p4.eta()) <= 2.7f)
 		{
-			// 2018 and UL2016-18 ID only: modified criteria for 2.6 < |eta| <= 2.7
+			// 2018 and 2016UL-18UL ID only: modified criteria for 2.6 < |eta| <= 2.7
 			if ((jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018) ||
-			    (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2016) ||
-			    (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017) ||
-			    (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2018))
+			    (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2016UL) ||
+			    (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2017UL) ||
+			    (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018UL))
 			{
 				// |eta| < 2.6
 				if (std::abs(jet->p4.eta()) < 2.6f)
@@ -379,9 +379,9 @@ public:
 				           (jet->photonFraction + jet->hfEMFraction > 0.02f) &&
 				           (jet->nConstituents - jet->nCharged > 2);
 			}
-			else if (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2016 ||
-			         jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017 ||
-			         jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2018)
+			else if (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2016UL ||
+			         jetIDVersion == KappaEnumTypes::JetIDVersion::ID2017UL ||
+			         jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018UL)
 			{
 				validJet = (jet->photonFraction + jet->hfEMFraction < 0.99f) &&
 				           (jet->photonFraction + jet->hfEMFraction > 0.01f) &&
@@ -409,9 +409,9 @@ public:
 				           (jet->neutralHadronFraction > 0.2f) &&
 				           (jet->nConstituents - jet->nCharged > 10);
 			}
-			else if (jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2016 ||
-			         jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2017 ||
-			         jetIDVersion == KappaEnumTypes::JetIDVersion::IDUL2018)
+			else if (jetIDVersion == KappaEnumTypes::JetIDVersion::ID2016UL ||
+			         jetIDVersion == KappaEnumTypes::JetIDVersion::ID2017UL ||
+			         jetIDVersion == KappaEnumTypes::JetIDVersion::ID2018UL)
 			{
 				validJet = (jet->photonFraction + jet->hfEMFraction < 0.90f) &&
 				           (jet->neutralHadronFraction > 0.2f) &&

--- a/KappaAnalysis/src/KappaEnumTypes.cc
+++ b/KappaAnalysis/src/KappaEnumTypes.cc
@@ -38,9 +38,9 @@ KappaEnumTypes::JetIDVersion KappaEnumTypes::ToJetIDVersion(std::string const& j
 	else if (jetIDVersion == "2016") return KappaEnumTypes::JetIDVersion::ID2016;
 	else if (jetIDVersion == "2017") return KappaEnumTypes::JetIDVersion::ID2017;
 	else if (jetIDVersion == "2018") return KappaEnumTypes::JetIDVersion::ID2018;
-	else if ((jetIDVersion == "2016UL") || (jetIDVersion == "UL2016")) return KappaEnumTypes::JetIDVersion::IDUL2016;
-	else if ((jetIDVersion == "2017UL") || (jetIDVersion == "UL2017")) return KappaEnumTypes::JetIDVersion::IDUL2017;
-	else if ((jetIDVersion == "2018UL") || (jetIDVersion == "UL2018")) return KappaEnumTypes::JetIDVersion::IDUL2018;
+	else if ((jetIDVersion == "2016UL") || (jetIDVersion == "UL2016")) return KappaEnumTypes::JetIDVersion::ID2016UL;
+	else if ((jetIDVersion == "2017UL") || (jetIDVersion == "UL2017")) return KappaEnumTypes::JetIDVersion::ID2017UL;
+	else if ((jetIDVersion == "2018UL") || (jetIDVersion == "UL2018")) return KappaEnumTypes::JetIDVersion::ID2018UL;
 	else LOG(FATAL) << "Jet ID version '" << jetIDVersion << "' is not available";
 	return KappaEnumTypes::JetIDVersion::ID2016;
 }

--- a/KappaAnalysis/src/KappaEnumTypes.cc
+++ b/KappaAnalysis/src/KappaEnumTypes.cc
@@ -38,6 +38,7 @@ KappaEnumTypes::JetIDVersion KappaEnumTypes::ToJetIDVersion(std::string const& j
 	else if (jetIDVersion == "2016") return KappaEnumTypes::JetIDVersion::ID2016;
 	else if (jetIDVersion == "2017") return KappaEnumTypes::JetIDVersion::ID2017;
 	else if (jetIDVersion == "2018") return KappaEnumTypes::JetIDVersion::ID2018;
+	else if ((jetIDVersion == "2017UL") || (jetIDVersion == "UL2017")) return KappaEnumTypes::JetIDVersion::IDUL2017;
 	else LOG(FATAL) << "Jet ID version '" << jetIDVersion << "' is not available";
 	return KappaEnumTypes::JetIDVersion::ID2016;
 }

--- a/KappaAnalysis/src/KappaEnumTypes.cc
+++ b/KappaAnalysis/src/KappaEnumTypes.cc
@@ -38,7 +38,9 @@ KappaEnumTypes::JetIDVersion KappaEnumTypes::ToJetIDVersion(std::string const& j
 	else if (jetIDVersion == "2016") return KappaEnumTypes::JetIDVersion::ID2016;
 	else if (jetIDVersion == "2017") return KappaEnumTypes::JetIDVersion::ID2017;
 	else if (jetIDVersion == "2018") return KappaEnumTypes::JetIDVersion::ID2018;
+	else if ((jetIDVersion == "2016UL") || (jetIDVersion == "UL2016")) return KappaEnumTypes::JetIDVersion::IDUL2016;
 	else if ((jetIDVersion == "2017UL") || (jetIDVersion == "UL2017")) return KappaEnumTypes::JetIDVersion::IDUL2017;
+	else if ((jetIDVersion == "2018UL") || (jetIDVersion == "UL2018")) return KappaEnumTypes::JetIDVersion::IDUL2018;
 	else LOG(FATAL) << "Jet ID version '" << jetIDVersion << "' is not available";
 	return KappaEnumTypes::JetIDVersion::ID2016;
 }


### PR DESCRIPTION
Extension for UL2017 JetID and fixes for 2017 and 2018 JetIDs have been included. The extension has been tested with an appropriate config file `/portal/ekpbms1/home/mhorzela/CMSSW_10_6_9_excalibur/src/Excalibur/cfg/excalibur/jec17ul/mc17_DYJets_madgraph/mc17_mm_BCDEF_DYJets_Madgraph_JECComplexL1.py` with
```python
    cfg['CutJetID'] = 'tightlepveto'  # choose event-based JetID selection
    cfg['CutJetIDVersion'] = '2017UL'  # for event-based JetID
    cfg['CutJetIDFirstNJets'] = 2
```
and proven successfull with the output `/portal/ekpbms1/home/mhorzela/CMSSW_10_6_9_excalibur/src/Excalibur/cfg/excalibur/jec17ul/mc17_DYJets_madgraph/mc17_mm_BCDEF_DYJets_Madgraph_JECComplexL1.root`. 


