### PR TITLE
Add leptonjet collection

### DIFF
--- a/KappaAnalysis/interface/KappaProduct.h
+++ b/KappaAnalysis/interface/KappaProduct.h
@@ -122,6 +122,7 @@ public:
 	/// added by ValidJetsProducer
 	std::vector<KBasicJet*> m_validJets;
 	std::vector<KBasicJet*> m_invalidJets;
+	std::map<KLepton*, KBasicJet*> m_leptonJetsMap;
 
 	/// added by ValidGenJetsProducer
 	std::vector<KGenJet*> m_validGenJets;
@@ -236,6 +237,8 @@ public:
 
 	// MVA outputs
 	std::vector<double> m_discriminators;
+
+
 
 	// GenPartonCounterProducer
 	int m_genNPartons = -1;

--- a/KappaAnalysis/interface/Producers/ValidJetsProducer.h
+++ b/KappaAnalysis/interface/Producers/ValidJetsProducer.h
@@ -221,14 +221,36 @@ public:
 			}
 		}
 
-                LOG(DEBUG) << "Initial size of jets: " << jets.size(); 
+                LOG(DEBUG) << "Initial size of jets: " << jets.size();
+
+		// find the clostest jet to each lepton prior to any filtering
+		for (std::vector<KLepton*>::const_iterator lepton = product.m_validLeptons.begin(); lepton != product.m_validLeptons.end(); ++lepton)
+		{
+			LOG(DEBUG) << "New Lepton: " << (*lepton)->p4;
+			float mindeltaR = 10.0;
+			product.m_leptonJetsMap[*lepton] =  static_cast<KBasicJet*>(nullptr) ;
+			for (typename std::vector<TJet*>::iterator jet = jets.begin(); jet != jets.end(); ++jet)
+			{
+				float tempdeltR = ROOT::Math::VectorUtil::DeltaR((*lepton)->p4, (*jet)->p4);
+				LOG(DEBUG) << " Testing New DeltaR: " << tempdeltR ;
+				if (tempdeltR < mindeltaR && tempdeltR < 0.5)
+				{
+					mindeltaR = tempdeltR;
+					product.m_leptonJetsMap[*lepton] = *jet;
+					LOG(DEBUG) << " Updated DeltaR to " << mindeltaR ;
+					LOG(DEBUG) << " New best Jet: " << (*jet)->p4;
+				}
+
+			}
+		}
+		LOG(DEBUG) << "LeptonJet map built";
 		for (typename std::vector<TJet*>::iterator jet = jets.begin(); jet != jets.end(); ++jet)
 		{
 			bool validJet = true;
-                        LOG(DEBUG) << "Checking jet with p4 " << (*jet)->p4; 
+                        LOG(DEBUG) << "Checking jet with p4 " << (*jet)->p4;
 
 			validJet = validJet && passesJetID(*jet, jetIDVersion, jetID);
-                        LOG(DEBUG) << "\tPassing ID's? " << validJet; 
+                        LOG(DEBUG) << "\tPassing ID's? " << validJet;
 
 			// remove leptons from list of jets via simple DeltaR isolation
 			for (std::vector<KLepton*>::const_iterator lepton = product.m_validLeptons.begin();


### PR DESCRIPTION
This PR adds leptonjets to the framework. The closted jet in deltaR to each lepton is saved in the `m_leptonJetsMap`. If no jet within deltaR = 0.5 around the lepton is found, a nullptr is saved for this lepton. 