### PR TITLE
Jet id default refactoring

### DIFF
--- a/KappaAnalysis/interface/KappaEnumTypes.h
+++ b/KappaAnalysis/interface/KappaEnumTypes.h
@@ -62,6 +62,7 @@ public:
 
 	enum class JetIDVersion : int
 	{
+		NONE = -1,
 		ID2010 = 0,  // old run1 version (most run 1 analyses)
 		ID2014 = 1,  // new run1 version (run 1 legacy: old version + muon fraction cut)
 		             // first run 2 version identical to run 1 legacy version

--- a/KappaAnalysis/interface/KappaSettings.h
+++ b/KappaAnalysis/interface/KappaSettings.h
@@ -225,9 +225,9 @@ public:
 	IMPL_SETTING_DEFAULT(bool, DirectIso, true);
 
 	IMPL_SETTING_DEFAULT(std::string, ValidMuonsInput, "auto");
-	IMPL_SETTING(std::string, MuonID);
-	IMPL_SETTING(std::string, MuonIsoType);
-	IMPL_SETTING(std::string, MuonIso);
+	IMPL_SETTING_DEFAULT(std::string, MuonID, "none");
+	IMPL_SETTING_DEFAULT(std::string, MuonIsoType, "none");
+	IMPL_SETTING_DEFAULT(std::string, MuonIso, "none");
 
 	IMPL_SETTING_DEFAULT(std::string, ValidElectronsInput, "auto");
 	IMPL_SETTING(std::string, ElectronID);
@@ -250,9 +250,9 @@ public:
 	IMPL_SETTING_DEFAULT(bool, UseJECShiftsForBJets, false);
 
 	IMPL_SETTING_DEFAULT(std::string, ValidJetsInput, "auto");
-	IMPL_SETTING(std::string, JetID);
-	IMPL_SETTING_DEFAULT(float, JetLeptonLowerDeltaRCut, -1.0f);
-	IMPL_SETTING_DEFAULT(std::string, JetIDVersion, "2010");
+	IMPL_SETTING_DEFAULT(std::string, JetID, "none");
+	IMPL_SETTING(float, JetLeptonLowerDeltaRCut);
+	IMPL_SETTING_DEFAULT(std::string, JetIDVersion, "none");
 	IMPL_SETTING_DEFAULT(std::string, PuJetIDFullDiscrName, "puJetIDFullDiscriminant");
 	IMPL_SETTING_STRINGLIST_DEFAULT(PuJetIDs, {});
 	IMPL_SETTING_STRINGLIST_DEFAULT(JetTaggerLowerCuts, {});

--- a/KappaAnalysis/src/KappaEnumTypes.cc
+++ b/KappaAnalysis/src/KappaEnumTypes.cc
@@ -23,6 +23,7 @@ KappaEnumTypes::DiLeptonDecayMode KappaEnumTypes::ToDiLeptonDecayMode(std::strin
 
 KappaEnumTypes::ValidJetsInput KappaEnumTypes::ToValidJetsInput(std::string const& validJetsInput)
 {
+	std::string validJetsInput_lower = boost::algorithm::to_lower_copy(boost::algorithm::trim_copy(validJetsInput));
 	if (validJetsInput == "uncorrected") return KappaEnumTypes::ValidJetsInput::UNCORRECTED;
 	else if (validJetsInput == "corrected") return KappaEnumTypes::ValidJetsInput::CORRECTED;
 	else return KappaEnumTypes::ValidJetsInput::AUTO;
@@ -43,20 +44,26 @@ KappaEnumTypes::JetIDVersion KappaEnumTypes::ToJetIDVersion(std::string const& j
 	else if ((jetIDVersionLower == "2016ul") || (jetIDVersionLower == "ul2016")) return KappaEnumTypes::JetIDVersion::ID2016UL;
 	else if ((jetIDVersionLower == "2017ul") || (jetIDVersionLower == "ul2017")) return KappaEnumTypes::JetIDVersion::ID2017UL;
 	else if ((jetIDVersionLower == "2018ul") || (jetIDVersionLower == "ul2018")) return KappaEnumTypes::JetIDVersion::ID2018UL;
-	else LOG(FATAL) << "Jet ID version '" << jetIDVersion << "' is not available";
-	return KappaEnumTypes::JetIDVersion::ID2016;
+	else if (jetIDVersionLower == "none") return KappaEnumTypes::JetIDVersion::NONE;
+	else {
+	    LOG(FATAL) << "[KappaEnumTypes] Jet ID version '" << jetIDVersion << "' is not available";
+	    return KappaEnumTypes::JetIDVersion::NONE; // necessary but never happens!
+	}
 }
 
 KappaEnumTypes::JetID KappaEnumTypes::ToJetID(std::string const& jetID)
 {
-	if (jetID == "loose") return KappaEnumTypes::JetID::LOOSE;
-	else if (jetID == "looselepveto") return KappaEnumTypes::JetID::LOOSELEPVETO;
-	else if (jetID == "medium") return KappaEnumTypes::JetID::MEDIUM;
-	else if (jetID == "tight") return KappaEnumTypes::JetID::TIGHT;
-	else if (jetID == "tightlepveto") return KappaEnumTypes::JetID::TIGHTLEPVETO;
-	else if (jetID == "none") return KappaEnumTypes::JetID::NONE;
-	else LOG(FATAL) << "Jet ID of type '" << jetID << "' not implemented!";
-	return KappaEnumTypes::JetID::NONE;
+	std::string jetIDLower = boost::algorithm::to_lower_copy(boost::algorithm::trim_copy(jetID));
+	if (jetIDLower == "loose") return KappaEnumTypes::JetID::LOOSE;
+	else if (jetIDLower == "looselepveto") return KappaEnumTypes::JetID::LOOSELEPVETO;
+	else if (jetIDLower == "medium") return KappaEnumTypes::JetID::MEDIUM;
+	else if (jetIDLower == "tight") return KappaEnumTypes::JetID::TIGHT;
+	else if (jetIDLower == "tightlepveto") return KappaEnumTypes::JetID::TIGHTLEPVETO;
+	else if (jetIDLower == "none") return KappaEnumTypes::JetID::NONE;
+	else {
+	    LOG(FATAL) << "Jet ID of type '" << jetID << "' not implemented!";
+	    return KappaEnumTypes::JetID::NONE; // necessary but never happens!
+	}
 }
 
 KappaEnumTypes::BTagScaleFactorMethod KappaEnumTypes::ToBTagScaleFactorMethod(std::string const& bTagSFMethod)


### PR DESCRIPTION
This PR introduces reasonable defaults for muonID and jetID.
The "to_lower" casting was moved to the related KappaEnumTypes::FUNCTION for the jetID stuff to reduce duplicated code.
Additionally, a logic to ensure a correct configuration was added to the ValidJetsProducerBase's passesJetID function.