### PR TITLE
add virtual destructors

### DIFF
--- a/Core/interface/EventProviderBase.h
+++ b/Core/interface/EventProviderBase.h
@@ -19,4 +19,6 @@ public:
 	virtual bool NewLumisection() const { return false; }
 	virtual bool NewRun() const { return false; }
 
+	virtual ~EventProviderBase() = default;
+
 };

--- a/Core/interface/Pipeline.h
+++ b/Core/interface/Pipeline.h
@@ -34,6 +34,7 @@ public:
 
 	virtual void InitPipeline(pipeline_type * pLine, setting_type const& pset) const {};
 
+	virtual ~PipelineInitilizerBase() = default;
 };
 
 /**

--- a/KappaAnalysis/interface/Utility/ValidPhysicsObjectTools.h
+++ b/KappaAnalysis/interface/Utility/ValidPhysicsObjectTools.h
@@ -40,6 +40,8 @@ public:
 		                                                               upperAbsEtaCutsByHltName);
 	}
 
+	virtual ~ValidPhysicsObjectTools() = default;
+
 
 protected:
 	


### PR DESCRIPTION
This PR removes all warnings like:
`warning: base class 'class ValidPhysicsObjectTools<ZJetTypes, KElectron>' has accessible non-virtual destructor [-Wnon-virtual-dtor]`
during compilation.

I hope this doesn't break anything. I'm no C++ expert, so I'm not sure. But so far it seems to work just fine and the compiler doesn't complain any more.